### PR TITLE
Initial commit of autogenerated Protobuf from ASN.1

### DIFF
--- a/api/buf.yaml
+++ b/api/buf.yaml
@@ -1,0 +1,6 @@
+lint:
+  use:
+    - DEFAULT
+    - FILE_LOWER_SNAKE_CASE
+  except:
+    - ENUM_ZERO_VALUE_SUFFIX

--- a/api/e2ap_v01_00_00_asn/v1/e2ap-commondatatypes.proto
+++ b/api/e2ap_v01_00_00_asn/v1/e2ap-commondatatypes.proto
@@ -1,0 +1,40 @@
+////////////////////// e2ap-commondatatypes.proto //////////////////////
+// Protobuf generated from /e2ap-v01.00.00.asn by asn1c-0.9.29
+// E2AP-CommonDataTypes { iso(1) identified-organization(3) dod(6) internet(1) private(4) enterprise(1) 53148 e2(1) version1(1) e2ap(1) e2ap-CommonDataTypes(3) }
+
+syntax = "proto3";
+
+package e2ap_v01_00_00_asn.v1;
+
+import "validate/v1/validate.proto";
+
+// enumerated from e2ap-v01.00.00.asn:1292
+enum Criticality {
+    CRITICALITY_REJECT = 0;
+    CRITICALITY_IGNORE = 1;
+    CRITICALITY_NOTIFY = 2;
+};
+
+// enumerated from e2ap-v01.00.00.asn:1294
+enum Presence {
+    PRESENCE_OPTIONAL = 0;
+    PRESENCE_CONDITIONAL = 1;
+    PRESENCE_MANDATORY = 2;
+};
+
+// enumerated from e2ap-v01.00.00.asn:1300
+enum TriggeringMessage {
+    TRIGGERING_MESSAGE_INITIATING_MESSAGE = 0;
+    TRIGGERING_MESSAGE_SUCCESSFUL_OUTCOME = 1;
+    TRIGGERING_MESSAGE_UNSUCCESSFULL_OUTCOME = 2;
+};
+
+// range of Integer from e2ap-v01.00.00.asn:1296
+message ProcedureCode {
+    int32 value = 1 [(validate.v1.rules).int32 = {gte: 0, lte: 255}];
+};
+
+// range of Integer from e2ap-v01.00.00.asn:1298
+message ProtocolIeId {
+    int32 value = 1 [(validate.v1.rules).int32 = {gte: 0, lte: 65535}];
+};

--- a/api/e2ap_v01_00_00_asn/v1/e2ap-constants.proto
+++ b/api/e2ap_v01_00_00_asn/v1/e2ap-constants.proto
@@ -1,0 +1,235 @@
+////////////////////// e2ap-constants.proto //////////////////////
+// Protobuf generated from /e2ap-v01.00.00.asn by asn1c-0.9.29
+// E2AP-Constants { iso(1) identified-organization(3) dod(6) internet(1) private(4) enterprise(1) 53148 e2(1) version1(1) e2ap(1) e2ap-Constants(4) }
+
+syntax = "proto3";
+
+package e2ap_v01_00_00_asn.v1;
+
+import "e2ap_v01_00_00_asn/v1/e2ap-commondatatypes.proto";
+import "validate/v1/validate.proto";
+
+// reference from e2ap-v01.00.00.asn:1360
+message IdE2setup {
+    int32 value = 1 [(validate.v1.rules).int32.const = 1]; // ProcedureCode
+};
+
+// reference from e2ap-v01.00.00.asn:1361
+message IdErrorIndication {
+    int32 value = 1 [(validate.v1.rules).int32.const = 2]; // ProcedureCode
+};
+
+// reference from e2ap-v01.00.00.asn:1362
+message IdReset {
+    int32 value = 1 [(validate.v1.rules).int32.const = 3]; // ProcedureCode
+};
+
+// reference from e2ap-v01.00.00.asn:1363
+message IdRiccontrol {
+    int32 value = 1 [(validate.v1.rules).int32.const = 4]; // ProcedureCode
+};
+
+// reference from e2ap-v01.00.00.asn:1364
+message IdRicindication {
+    int32 value = 1 [(validate.v1.rules).int32.const = 5]; // ProcedureCode
+};
+
+// reference from e2ap-v01.00.00.asn:1365
+message IdRicserviceQuery {
+    int32 value = 1 [(validate.v1.rules).int32.const = 6]; // ProcedureCode
+};
+
+// reference from e2ap-v01.00.00.asn:1366
+message IdRicserviceUpdate {
+    int32 value = 1 [(validate.v1.rules).int32.const = 7]; // ProcedureCode
+};
+
+// reference from e2ap-v01.00.00.asn:1367
+message IdRicsubscription {
+    int32 value = 1 [(validate.v1.rules).int32.const = 8]; // ProcedureCode
+};
+
+// reference from e2ap-v01.00.00.asn:1368
+message IdRicsubscriptionDelete {
+    int32 value = 1 [(validate.v1.rules).int32.const = 9]; // ProcedureCode
+};
+
+// constant Integer from e2ap-v01.00.00.asn:1376
+message MaxProtocolIes {
+    int32 value = 1 [(validate.v1.rules).int32.const = 65535];
+};
+
+// constant Integer from e2ap-v01.00.00.asn:1384
+message MaxnoofErrors {
+    int32 value = 1 [(validate.v1.rules).int32.const = 256];
+};
+
+// constant Integer from e2ap-v01.00.00.asn:1385
+message MaxofRanfunctionId {
+    int32 value = 1 [(validate.v1.rules).int32.const = 256];
+};
+
+// constant Integer from e2ap-v01.00.00.asn:1386
+message MaxofRicactionId {
+    int32 value = 1 [(validate.v1.rules).int32.const = 16];
+};
+
+// reference from e2ap-v01.00.00.asn:1393
+message IdCause {
+    int32 value = 1 [(validate.v1.rules).int32.const = 1]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1394
+message IdCriticalityDiagnostics {
+    int32 value = 1 [(validate.v1.rules).int32.const = 2]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1395
+message IdGlobalE2nodeId {
+    int32 value = 1 [(validate.v1.rules).int32.const = 3]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1396
+message IdGlobalRicId {
+    int32 value = 1 [(validate.v1.rules).int32.const = 4]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1397
+message IdRanfunctionId {
+    int32 value = 1 [(validate.v1.rules).int32.const = 5]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1398
+message IdRanfunctionIdItem {
+    int32 value = 1 [(validate.v1.rules).int32.const = 6]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1399
+message IdRanfunctionIecauseItem {
+    int32 value = 1 [(validate.v1.rules).int32.const = 7]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1400
+message IdRanfunctionItem {
+    int32 value = 1 [(validate.v1.rules).int32.const = 8]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1401
+message IdRanfunctionsAccepted {
+    int32 value = 1 [(validate.v1.rules).int32.const = 9]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1402
+message IdRanfunctionsAdded {
+    int32 value = 1 [(validate.v1.rules).int32.const = 10]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1403
+message IdRanfunctionsDeleted {
+    int32 value = 1 [(validate.v1.rules).int32.const = 11]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1404
+message IdRanfunctionsModified {
+    int32 value = 1 [(validate.v1.rules).int32.const = 12]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1405
+message IdRanfunctionsRejected {
+    int32 value = 1 [(validate.v1.rules).int32.const = 13]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1406
+message IdRicactionAdmittedItem {
+    int32 value = 1 [(validate.v1.rules).int32.const = 14]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1407
+message IdRicactionId {
+    int32 value = 1 [(validate.v1.rules).int32.const = 15]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1408
+message IdRicactionNotAdmittedItem {
+    int32 value = 1 [(validate.v1.rules).int32.const = 16]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1409
+message IdRicactionsAdmitted {
+    int32 value = 1 [(validate.v1.rules).int32.const = 17]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1410
+message IdRicactionsNotAdmitted {
+    int32 value = 1 [(validate.v1.rules).int32.const = 18]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1411
+message IdRicactionToBeSetupItem {
+    int32 value = 1 [(validate.v1.rules).int32.const = 19]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1412
+message IdRiccallProcessId {
+    int32 value = 1 [(validate.v1.rules).int32.const = 20]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1413
+message IdRiccontrolAckRequest {
+    int32 value = 1 [(validate.v1.rules).int32.const = 21]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1414
+message IdRiccontrolHeader {
+    int32 value = 1 [(validate.v1.rules).int32.const = 22]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1415
+message IdRiccontrolMessage {
+    int32 value = 1 [(validate.v1.rules).int32.const = 23]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1416
+message IdRiccontrolStatus {
+    int32 value = 1 [(validate.v1.rules).int32.const = 24]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1417
+message IdRicindicationHeader {
+    int32 value = 1 [(validate.v1.rules).int32.const = 25]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1418
+message IdRicindicationMessage {
+    int32 value = 1 [(validate.v1.rules).int32.const = 26]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1419
+message IdRicindicationSn {
+    int32 value = 1 [(validate.v1.rules).int32.const = 27]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1420
+message IdRicindicationType {
+    int32 value = 1 [(validate.v1.rules).int32.const = 28]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1421
+message IdRicrequestId {
+    int32 value = 1 [(validate.v1.rules).int32.const = 29]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1422
+message IdRicsubscriptionDetails {
+    int32 value = 1 [(validate.v1.rules).int32.const = 30]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1423
+message IdTimeToWait {
+    int32 value = 1 [(validate.v1.rules).int32.const = 31]; // ProtocolIE-ID
+};
+
+// reference from e2ap-v01.00.00.asn:1424
+message IdRiccontrolOutcome {
+    int32 value = 1 [(validate.v1.rules).int32.const = 32]; // ProtocolIE-ID
+};

--- a/api/e2ap_v01_00_00_asn/v1/e2ap-containers.proto
+++ b/api/e2ap_v01_00_00_asn/v1/e2ap-containers.proto
@@ -1,0 +1,64 @@
+////////////////////// e2ap-containers.proto //////////////////////
+// Protobuf generated from /e2ap-v01.00.00.asn by asn1c-0.9.29
+// E2AP-Containers { iso(1) identified-organization(3) dod(6) internet(1) private(4) enterprise(1) 53148 e2(1) version1(1) e2ap(1) e2ap-Containers(5) }
+
+syntax = "proto3";
+
+package e2ap_v01_00_00_asn.v1;
+
+import "e2ap_v01_00_00_asn/v1/e2ap-commondatatypes.proto";
+import "e2ap_v01_00_00_asn/v1/e2ap-constants.proto";
+import "validate/v1/validate.proto";
+
+// sequence from e2ap-v01.00.00.asn:1544
+// Param E2AP-PROTOCOL-IES:IEsSetParam
+message ProtocolIeContainer001 {
+    repeated ProtocolIeField value = 1;
+};
+
+// reference from e2ap-v01.00.00.asn:1547
+// Param E2AP-PROTOCOL-IES:IEsSetParam
+message ProtocolIeSingleContainer001 {
+    ProtocolIeField001 value = 1;
+};
+
+// sequence from e2ap-v01.00.00.asn:1550
+// Param E2AP-PROTOCOL-IES:IEsSetParam
+message ProtocolIeField001 {
+    <type> id = 1;
+    @id criticality = 2;
+    @id value = 3;
+};
+
+// sequence from e2ap-v01.00.00.asn:1563
+// Param E2AP-PROTOCOL-IES-PAIR:IEsSetParam
+message ProtocolIeContainerPair {
+    repeated ProtocolIeFieldPair value = 1;
+};
+
+// sequence from e2ap-v01.00.00.asn:1566
+// Param E2AP-PROTOCOL-IES-PAIR:IEsSetParam
+message ProtocolIeFieldPair {
+    IesSetParam id = 1;
+    @id first_criticality = 2;
+    @id first_value = 3;
+    @id second_criticality = 4;
+    @id second_value = 5;
+};
+
+// sequence from e2ap-v01.00.00.asn:1581
+// Param INTEGER:lowerBound
+// Param INTEGER:upperBound
+// Param E2AP-PROTOCOL-IES:IEsSetParam
+message ProtocolIeContainerList {
+    repeated ProtocolIeSingleContainer value = 1;
+};
+
+// sequence from e2ap-v01.00.00.asn:1585
+// Param INTEGER:lowerBound
+// Param INTEGER:upperBound
+// Param E2AP-PROTOCOL-IES-PAIR:IEsSetParam
+message ProtocolIeContainerPairList {
+    repeated ProtocolIeContainerPair value = 1;
+};
+

--- a/api/e2ap_v01_00_00_asn/v1/e2ap-ies.proto
+++ b/api/e2ap_v01_00_00_asn/v1/e2ap-ies.proto
@@ -1,0 +1,304 @@
+////////////////////// e2ap-ies.proto //////////////////////
+// Protobuf generated from /e2ap-v01.00.00.asn by asn1c-0.9.29
+// E2AP-IEs { iso(1) identified-organization(3) dod(6) internet(1) private(4) enterprise(1) 53148 e2(1) version1(1) e2ap(1) e2ap-IEs(2) }
+
+syntax = "proto3";
+
+package e2ap_v01_00_00_asn.v1;
+
+import "e2ap_v01_00_00_asn/v1/e2ap-commondatatypes.proto";
+import "e2ap_v01_00_00_asn/v1/e2ap-constants.proto";
+import "validate/v1/validate.proto";
+
+// enumerated from e2ap-v01.00.00.asn:908
+enum CauseMisc {
+    CAUSE_MISC_CONTROL_PROCESSING_OVERLOAD = 0;
+    CAUSE_MISC_HARDWARE_FAILURE = 1;
+    CAUSE_MISC_OM_INTERVENTION = 2;
+    CAUSE_MISC_UNSPECIFIED = 3;
+};
+
+// enumerated from e2ap-v01.00.00.asn:915
+enum CauseProtocol {
+    CAUSE_PROTOCOL_TRANSFER_SYNTAX_ERROR = 0;
+    CAUSE_PROTOCOL_ABSTRACT_SYNTAX_ERROR_REJECT = 1;
+    CAUSE_PROTOCOL_ABSTRACT_SYNTAX_ERROR_IGNORE_AND_NOTIFY = 2;
+    CAUSE_PROTOCOL_MESSAGE_NOT_COMPATIBLE_WITH_RECEIVER_STATE = 3;
+    CAUSE_PROTOCOL_SEMANTIC_ERROR = 4;
+    CAUSE_PROTOCOL_ABSTRACT_SYNTAX_ERROR_FALSELY_CONSTRUCTED_MESSAGE = 5;
+    CAUSE_PROTOCOL_UNSPECIFIED = 6;
+};
+
+// enumerated from e2ap-v01.00.00.asn:926
+enum CauseRic {
+    CAUSE_RIC_RAN_FUNCTION_ID__INVALID = 0;
+    CAUSE_RIC_ACTION_NOT_SUPPORTED = 1;
+    CAUSE_RIC_EXCESSIVE_ACTIONS = 2;
+    CAUSE_RIC_DUPLICATE_ACTION = 3;
+    CAUSE_RIC_DUPLICATE_EVENT = 4;
+    CAUSE_RIC_FUNCTION_RESOURCE_LIMIT = 5;
+    CAUSE_RIC_REQUEST_ID_UNKNOWN = 6;
+    CAUSE_RIC_INCONSISTENT_ACTION_SUBSEQUENT_ACTION_SEQUENCE = 7;
+    CAUSE_RIC_CONTROL_MESSAGE_INVALID = 8;
+    CAUSE_RIC_CALL_PROCESS_ID_INVALID = 9;
+    CAUSE_RIC_UNSPECIFIED = 10;
+};
+
+// enumerated from e2ap-v01.00.00.asn:941
+enum CauseRicservice {
+    CAUSE_RICSERVICE_FUNCTION_NOT_REQUIRED = 0;
+    CAUSE_RICSERVICE_EXCESSIVE_FUNCTIONS = 1;
+    CAUSE_RICSERVICE_RIC_RESOURCE_LIMIT = 2;
+};
+
+// enumerated from e2ap-v01.00.00.asn:947
+enum CauseTransport {
+    CAUSE_TRANSPORT_UNSPECIFIED = 0;
+    CAUSE_TRANSPORT_TRANSPORT_RESOURCE_UNAVAILABLE = 1;
+};
+
+// enumerated from e2ap-v01.00.00.asn:1126
+enum RicactionType {
+    RICACTION_TYPE_REPORT = 0;
+    RICACTION_TYPE_INSERT = 1;
+    RICACTION_TYPE_POLICY = 2;
+};
+
+// enumerated from e2ap-v01.00.00.asn:1138
+enum RiccontrolAckRequest {
+    RICCONTROL_ACK_REQUEST_NO_ACK = 0;
+    RICCONTROL_ACK_REQUEST_ACK = 1;
+    RICCONTROL_ACK_REQUEST_N_ACK = 2;
+};
+
+// enumerated from e2ap-v01.00.00.asn:1160
+enum RiccontrolStatus {
+    RICCONTROL_STATUS_SUCCESS = 0;
+    RICCONTROL_STATUS_REJECTED = 1;
+    RICCONTROL_STATUS_FAILED = 2;
+};
+
+// enumerated from e2ap-v01.00.00.asn:1184
+enum RicindicationType {
+    RICINDICATION_TYPE_REPORT = 0;
+    RICINDICATION_TYPE_INSERT = 1;
+};
+
+// enumerated from e2ap-v01.00.00.asn:1202
+enum RicsubsequentActionType {
+    RICSUBSEQUENT_ACTION_TYPE_CONTINUE = 0;
+    RICSUBSEQUENT_ACTION_TYPE_WAIT = 1;
+};
+
+// enumerated from e2ap-v01.00.00.asn:1208
+enum RictimeToWait {
+    RICTIME_TO_WAIT_ZERO = 0;
+    RICTIME_TO_WAIT_W1MS = 1;
+    RICTIME_TO_WAIT_W2MS = 2;
+    RICTIME_TO_WAIT_W5MS = 3;
+    RICTIME_TO_WAIT_W10MS = 4;
+    RICTIME_TO_WAIT_W20MS = 5;
+    RICTIME_TO_WAIT_W30MS = 6;
+    RICTIME_TO_WAIT_W40MS = 7;
+    RICTIME_TO_WAIT_W50MS = 8;
+    RICTIME_TO_WAIT_W100MS = 9;
+    RICTIME_TO_WAIT_W200MS = 10;
+    RICTIME_TO_WAIT_W500MS = 11;
+    RICTIME_TO_WAIT_W1S = 12;
+    RICTIME_TO_WAIT_W2S = 13;
+    RICTIME_TO_WAIT_W5S = 14;
+    RICTIME_TO_WAIT_W10S = 15;
+    RICTIME_TO_WAIT_W20S = 16;
+    RICTIME_TO_WAIT_W60S = 17;
+};
+
+// enumerated from e2ap-v01.00.00.asn:1233
+enum TimeToWait {
+    TIME_TO_WAIT_V1S = 0;
+    TIME_TO_WAIT_V2S = 1;
+    TIME_TO_WAIT_V5S = 2;
+    TIME_TO_WAIT_V10S = 3;
+    TIME_TO_WAIT_V20S = 4;
+    TIME_TO_WAIT_V60S = 5;
+};
+
+// enumerated from e2ap-v01.00.00.asn:1239
+enum TypeOfError {
+    TYPE_OF_ERROR_NOT_UNDERSTOOD = 0;
+    TYPE_OF_ERROR_MISSING = 1;
+};
+
+// sequence from e2ap-v01.00.00.asn:899
+message Cause {
+    // choice from e2ap-v01.00.00.asn:899
+    oneof cause {
+        CauseRic ric_request = 1;
+        CauseRicservice ric_service = 2;
+        CauseTransport transport = 3;
+        CauseProtocol protocol = 4;
+        CauseMisc misc = 5;
+    }
+};
+
+// sequence from e2ap-v01.00.00.asn:957
+message CriticalityDiagnostics {
+    ProcedureCode procedure_code = 1;
+    TriggeringMessage triggering_message = 2;
+    Criticality procedure_criticality = 3;
+    RicrequestId ric_requestor_id = 4;
+    CriticalityDiagnosticsIeList i_es_criticality_diagnostics = 5;
+};
+
+// sequence from e2ap-v01.00.00.asn:967
+message CriticalityDiagnosticsIeList {
+    repeated CriticalityDiagnosticsIeItem value = 1;
+};
+
+// sequence from e2ap-v01.00.00.asn:968
+message CriticalityDiagnosticsIeItem {
+    Criticality i_ecriticality = 1;
+    ProtocolIeId i_e_id = 2;
+    TypeOfError type_of_error = 3;
+};
+
+// sequence from e2ap-v01.00.00.asn:982
+message EnbId {
+    // choice from e2ap-v01.00.00.asn:982
+    oneof enb_id {
+        BitString macro_e_nb_id = 1;
+        BitString home_e_nb_id = 2;
+        BitString short_macro_e_nb_id = 3;
+        BitString long_macro_e_nb_id = 4;
+    }
+};
+
+// sequence from e2ap-v01.00.00.asn:992
+message EnbIdChoice {
+    // choice from e2ap-v01.00.00.asn:992
+    oneof enb_id_choice {
+        BitString enb_id_macro = 1;
+        BitString enb_id_shortmacro = 2;
+        BitString enb_id_longmacro = 3;
+    }
+};
+
+// sequence from e2ap-v01.00.00.asn:1004
+message EngnbId {
+    // choice from e2ap-v01.00.00.asn:1004
+    oneof engnb_id {
+        BitString g_nb_id = 1;
+    }
+};
+
+// sequence from e2ap-v01.00.00.asn:1011
+message GlobalE2nodeId {
+    // choice from e2ap-v01.00.00.asn:1011
+    oneof global_e2node_id {
+        GlobalE2nodeGnbId g_nb = 1;
+        GlobalE2nodeEnGnbId en_g_nb = 2;
+        GlobalE2nodeNgEnbId ng_e_nb = 3;
+        GlobalE2nodeEnbId e_nb = 4;
+    }
+};
+
+// sequence from e2ap-v01.00.00.asn:1019
+message GlobalE2nodeEnGnbId {
+    GlobalenGnbId global_g_nb_id = 1;
+};
+
+// sequence from e2ap-v01.00.00.asn:1023
+message GlobalE2nodeEnbId {
+    GlobalEnbId global_e_nb_id = 1;
+};
+
+// sequence from e2ap-v01.00.00.asn:1027
+message GlobalE2nodeGnbId {
+    GlobalgNbId global_g_nb_id = 1;
+    GnbCuUpId g_nb_cu_up_id = 2;
+    GnbDuId g_nb_du_id = 3;
+};
+
+// sequence from e2ap-v01.00.00.asn:1033
+message GlobalE2nodeNgEnbId {
+    GlobalngeNbId global_ng_e_nb_id = 1;
+};
+
+// sequence from e2ap-v01.00.00.asn:1042
+message GlobalEnbId {
+    PlmnIdentity p_lmn_identity = 1;
+    EnbId e_nb_id = 2;
+};
+
+// sequence from e2ap-v01.00.00.asn:1051
+message GlobalenGnbId {
+    PlmnIdentity p_lmn_identity = 1;
+    EngnbId g_nb_id = 2;
+};
+
+// sequence from e2ap-v01.00.00.asn:1059
+message GlobalgNbId {
+    PlmnIdentity plmn_id = 1;
+    GnbIdChoice gnb_id = 2;
+};
+
+// sequence from e2ap-v01.00.00.asn:1069
+message GlobalngeNbId {
+    PlmnIdentity plmn_id = 1;
+    EnbIdChoice enb_id = 2;
+};
+
+// sequence from e2ap-v01.00.00.asn:1075
+message GlobalRicId {
+    PlmnIdentity p_lmn_identity = 1;
+    BitString ric_id = 2;
+};
+
+// range of Integer from e2ap-v01.00.00.asn:1083
+message GnbCuUpId {
+    int32 value = 1 [(validate.v1.rules).int32 = {gte: 0, lte: 68719476735}];
+};
+
+// range of Integer from e2ap-v01.00.00.asn:1084
+message GnbDuId {
+    int32 value = 1 [(validate.v1.rules).int32 = {gte: 0, lte: 68719476735}];
+};
+
+// sequence from e2ap-v01.00.00.asn:1090
+message GnbIdChoice {
+    // choice from e2ap-v01.00.00.asn:1090
+    oneof gnb_id_choice {
+        BitString gnb_id = 1;
+    }
+};
+
+// range of Integer from e2ap-v01.00.00.asn:1114
+message RanfunctionId {
+    int32 value = 1 [(validate.v1.rules).int32 = {gte: 0, lte: 4095}];
+};
+
+// range of Integer from e2ap-v01.00.00.asn:1116
+message RanfunctionRevision {
+    int32 value = 1 [(validate.v1.rules).int32 = {gte: 0, lte: 4095}];
+};
+
+// range of Integer from e2ap-v01.00.00.asn:1123
+message RicactionId {
+    int32 value = 1 [(validate.v1.rules).int32 = {gte: 0, lte: 255}];
+};
+
+// range of Integer from e2ap-v01.00.00.asn:1181
+message RicindicationSn {
+    int32 value = 1 [(validate.v1.rules).int32 = {gte: 0, lte: 65535}];
+};
+
+// sequence from e2ap-v01.00.00.asn:1190
+message RicrequestId {
+    int32 ric_requestor_id = 1;
+    int32 ric_instance_id = 2;
+};
+
+// sequence from e2ap-v01.00.00.asn:1196
+message RicsubsequentAction {
+    RicsubsequentActionType ric_subsequent_action_type = 1;
+    RictimeToWait ric_time_to_wait = 2;
+};

--- a/api/e2ap_v01_00_00_asn/v1/e2ap-pdu-contents.proto
+++ b/api/e2ap_v01_00_00_asn/v1/e2ap-pdu-contents.proto
@@ -1,0 +1,639 @@
+////////////////////// e2ap-pdu-contents.proto //////////////////////
+// Protobuf generated from /e2ap-v01.00.00.asn by asn1c-0.9.29
+// E2AP-PDU-Contents { iso(1) identified-organization(3) dod(6) internet(1) private(4) enterprise(1) 53148 e2(1) version1(1) e2ap(1) e2ap-PDU-Contents(1) }
+
+syntax = "proto3";
+
+package e2ap_v01_00_00_asn.v1;
+
+import "e2ap_v01_00_00_asn/v1/e2ap-ies.proto";
+import "e2ap_v01_00_00_asn/v1/e2ap-containers.proto";
+import "e2ap_v01_00_00_asn/v1/e2ap-constants.proto";
+import "validate/v1/validate.proto";
+
+// sequence from e2ap-v01.00.00.asn:354
+message RicsubscriptionRequest {
+    ProtocolIeContainer protocol_ies = 1;
+};
+
+// concrete instance(s) of class E2AP-PROTOCOL-IES from e2ap-v01.00.00.asn:358
+message RicsubscriptionRequestIes {
+    oneof ricsubscription_request_ies {
+        RicsubscriptionRequestIes001 instance001 = 1;
+        RicsubscriptionRequestIes002 instance002 = 2;
+        RicsubscriptionRequestIes003 instance003 = 3;
+    }
+    message RicsubscriptionRequestIes001 {
+        RicrequestId value = 1;
+    };
+
+    message RicsubscriptionRequestIes002 {
+        RanfunctionId value = 1;
+    };
+
+    message RicsubscriptionRequestIes003 {
+        RicsubscriptionDetails value = 1;
+    };
+
+};
+
+// sequence from e2ap-v01.00.00.asn:367
+message RicsubscriptionDetails {
+    RiceventTriggerDefinition ric_event_trigger_definition = 1;
+    RicactionsToBeSetupList ric_action_to_be_setup_list = 2;
+};
+
+// sequence from e2ap-v01.00.00.asn:372
+message RicactionsToBeSetupList {
+    repeated ProtocolIeSingleContainer value = 1;
+};
+
+// concrete instance(s) of class E2AP-PROTOCOL-IES from e2ap-v01.00.00.asn:374
+message RicactionToBeSetupItemIes {
+};
+
+// sequence from e2ap-v01.00.00.asn:380
+message RicactionToBeSetupItem {
+    RicactionId ric_action_id = 1;
+    RicactionType ric_action_type = 2;
+    RicactionDefinition ric_action_definition = 3;
+    RicsubsequentAction ric_subsequent_action = 4;
+};
+
+// sequence from e2ap-v01.00.00.asn:393
+message RicsubscriptionResponse {
+    ProtocolIeContainer protocol_ies = 1;
+};
+
+// concrete instance(s) of class E2AP-PROTOCOL-IES from e2ap-v01.00.00.asn:397
+message RicsubscriptionResponseIes {
+    oneof ricsubscription_response_ies {
+        RicsubscriptionResponseIes001 instance001 = 1;
+        RicsubscriptionResponseIes002 instance002 = 2;
+        RicsubscriptionResponseIes003 instance003 = 3;
+        RicsubscriptionResponseIes004 instance004 = 4;
+    }
+    message RicsubscriptionResponseIes001 {
+        RicrequestId value = 1;
+    };
+
+    message RicsubscriptionResponseIes002 {
+        RanfunctionId value = 1;
+    };
+
+    message RicsubscriptionResponseIes003 {
+        RicactionAdmittedList value = 1;
+    };
+
+    message RicsubscriptionResponseIes004 {
+        RicactionNotAdmittedList value = 1;
+    };
+
+};
+
+// sequence from e2ap-v01.00.00.asn:407
+message RicactionAdmittedList {
+    repeated ProtocolIeSingleContainer value = 1;
+};
+
+// concrete instance(s) of class E2AP-PROTOCOL-IES from e2ap-v01.00.00.asn:409
+message RicactionAdmittedItemIes {
+};
+
+// sequence from e2ap-v01.00.00.asn:415
+message RicactionAdmittedItem {
+    RicactionId ric_action_id = 1;
+};
+
+// sequence from e2ap-v01.00.00.asn:419
+message RicactionNotAdmittedList {
+    repeated ProtocolIeSingleContainer value = 1;
+};
+
+// concrete instance(s) of class E2AP-PROTOCOL-IES from e2ap-v01.00.00.asn:421
+message RicactionNotAdmittedItemIes {
+};
+
+// sequence from e2ap-v01.00.00.asn:427
+message RicactionNotAdmittedItem {
+    RicactionId ric_action_id = 1;
+    Cause cause = 2;
+};
+
+// sequence from e2ap-v01.00.00.asn:438
+message RicsubscriptionFailure {
+    ProtocolIeContainer protocol_ies = 1;
+};
+
+// concrete instance(s) of class E2AP-PROTOCOL-IES from e2ap-v01.00.00.asn:442
+message RicsubscriptionFailureIes {
+    oneof ricsubscription_failure_ies {
+        RicsubscriptionFailureIes001 instance001 = 1;
+        RicsubscriptionFailureIes002 instance002 = 2;
+        RicsubscriptionFailureIes003 instance003 = 3;
+        RicsubscriptionFailureIes004 instance004 = 4;
+    }
+    message RicsubscriptionFailureIes001 {
+        RicrequestId value = 1;
+    };
+
+    message RicsubscriptionFailureIes002 {
+        RanfunctionId value = 1;
+    };
+
+    message RicsubscriptionFailureIes003 {
+        RicactionNotAdmittedList value = 1;
+    };
+
+    message RicsubscriptionFailureIes004 {
+        CriticalityDiagnostics value = 1;
+    };
+
+};
+
+// sequence from e2ap-v01.00.00.asn:461
+message RicsubscriptionDeleteRequest {
+    ProtocolIeContainer protocol_ies = 1;
+};
+
+// concrete instance(s) of class E2AP-PROTOCOL-IES from e2ap-v01.00.00.asn:465
+message RicsubscriptionDeleteRequestIes {
+    oneof ricsubscription_delete_request_ies {
+        RicsubscriptionDeleteRequestIes001 instance001 = 1;
+        RicsubscriptionDeleteRequestIes002 instance002 = 2;
+    }
+    message RicsubscriptionDeleteRequestIes001 {
+        RicrequestId value = 1;
+    };
+
+    message RicsubscriptionDeleteRequestIes002 {
+        RanfunctionId value = 1;
+    };
+
+};
+
+// sequence from e2ap-v01.00.00.asn:477
+message RicsubscriptionDeleteResponse {
+    ProtocolIeContainer protocol_ies = 1;
+};
+
+// concrete instance(s) of class E2AP-PROTOCOL-IES from e2ap-v01.00.00.asn:481
+message RicsubscriptionDeleteResponseIes {
+    oneof ricsubscription_delete_response_ies {
+        RicsubscriptionDeleteResponseIes001 instance001 = 1;
+        RicsubscriptionDeleteResponseIes002 instance002 = 2;
+    }
+    message RicsubscriptionDeleteResponseIes001 {
+        RicrequestId value = 1;
+    };
+
+    message RicsubscriptionDeleteResponseIes002 {
+        RanfunctionId value = 1;
+    };
+
+};
+
+// sequence from e2ap-v01.00.00.asn:492
+message RicsubscriptionDeleteFailure {
+    ProtocolIeContainer protocol_ies = 1;
+};
+
+// concrete instance(s) of class E2AP-PROTOCOL-IES from e2ap-v01.00.00.asn:496
+message RicsubscriptionDeleteFailureIes {
+    oneof ricsubscription_delete_failure_ies {
+        RicsubscriptionDeleteFailureIes001 instance001 = 1;
+        RicsubscriptionDeleteFailureIes002 instance002 = 2;
+        RicsubscriptionDeleteFailureIes003 instance003 = 3;
+        RicsubscriptionDeleteFailureIes004 instance004 = 4;
+    }
+    message RicsubscriptionDeleteFailureIes001 {
+        RicrequestId value = 1;
+    };
+
+    message RicsubscriptionDeleteFailureIes002 {
+        RanfunctionId value = 1;
+    };
+
+    message RicsubscriptionDeleteFailureIes003 {
+        Cause value = 1;
+    };
+
+    message RicsubscriptionDeleteFailureIes004 {
+        CriticalityDiagnostics value = 1;
+    };
+
+};
+
+// sequence from e2ap-v01.00.00.asn:515
+message Ricindication {
+    ProtocolIeContainer protocol_ies = 1;
+};
+
+// concrete instance(s) of class E2AP-PROTOCOL-IES from e2ap-v01.00.00.asn:519
+message RicindicationIes {
+    oneof ricindication_ies {
+        RicindicationIes001 instance001 = 1;
+        RicindicationIes002 instance002 = 2;
+        RicindicationIes003 instance003 = 3;
+        RicindicationIes004 instance004 = 4;
+        RicindicationIes005 instance005 = 5;
+        RicindicationIes006 instance006 = 6;
+        RicindicationIes007 instance007 = 7;
+        RicindicationIes008 instance008 = 8;
+    }
+    message RicindicationIes001 {
+        RicrequestId value = 1;
+    };
+
+    message RicindicationIes002 {
+        RanfunctionId value = 1;
+    };
+
+    message RicindicationIes003 {
+        RicactionId value = 1;
+    };
+
+    message RicindicationIes004 {
+        RicindicationSn value = 1;
+    };
+
+    message RicindicationIes005 {
+        RicindicationType value = 1;
+    };
+
+    message RicindicationIes006 {
+        RicindicationHeader value = 1;
+    };
+
+    message RicindicationIes007 {
+        RicindicationMessage value = 1;
+    };
+
+    message RicindicationIes008 {
+        RiccallProcessId value = 1;
+    };
+
+};
+
+// sequence from e2ap-v01.00.00.asn:542
+message RiccontrolRequest {
+    ProtocolIeContainer protocol_ies = 1;
+};
+
+// concrete instance(s) of class E2AP-PROTOCOL-IES from e2ap-v01.00.00.asn:546
+message RiccontrolRequestIes {
+    oneof riccontrol_request_ies {
+        RiccontrolRequestIes001 instance001 = 1;
+        RiccontrolRequestIes002 instance002 = 2;
+        RiccontrolRequestIes003 instance003 = 3;
+        RiccontrolRequestIes004 instance004 = 4;
+        RiccontrolRequestIes005 instance005 = 5;
+        RiccontrolRequestIes006 instance006 = 6;
+    }
+    message RiccontrolRequestIes001 {
+        RicrequestId value = 1;
+    };
+
+    message RiccontrolRequestIes002 {
+        RanfunctionId value = 1;
+    };
+
+    message RiccontrolRequestIes003 {
+        RiccallProcessId value = 1;
+    };
+
+    message RiccontrolRequestIes004 {
+        RiccontrolHeader value = 1;
+    };
+
+    message RiccontrolRequestIes005 {
+        RiccontrolMessage value = 1;
+    };
+
+    message RiccontrolRequestIes006 {
+        RiccontrolAckRequest value = 1;
+    };
+
+};
+
+// sequence from e2ap-v01.00.00.asn:561
+message RiccontrolAcknowledge {
+    ProtocolIeContainer protocol_ies = 1;
+};
+
+// concrete instance(s) of class E2AP-PROTOCOL-IES from e2ap-v01.00.00.asn:565
+message RiccontrolAcknowledgeIes {
+    oneof riccontrol_acknowledge_ies {
+        RiccontrolAcknowledgeIes001 instance001 = 1;
+        RiccontrolAcknowledgeIes002 instance002 = 2;
+        RiccontrolAcknowledgeIes003 instance003 = 3;
+        RiccontrolAcknowledgeIes004 instance004 = 4;
+        RiccontrolAcknowledgeIes005 instance005 = 5;
+    }
+    message RiccontrolAcknowledgeIes001 {
+        RicrequestId value = 1;
+    };
+
+    message RiccontrolAcknowledgeIes002 {
+        RanfunctionId value = 1;
+    };
+
+    message RiccontrolAcknowledgeIes003 {
+        RiccallProcessId value = 1;
+    };
+
+    message RiccontrolAcknowledgeIes004 {
+        RiccontrolStatus value = 1;
+    };
+
+    message RiccontrolAcknowledgeIes005 {
+        RiccontrolOutcome value = 1;
+    };
+
+};
+
+// sequence from e2ap-v01.00.00.asn:579
+message RiccontrolFailure {
+    ProtocolIeContainer protocol_ies = 1;
+};
+
+// concrete instance(s) of class E2AP-PROTOCOL-IES from e2ap-v01.00.00.asn:583
+message RiccontrolFailureIes {
+    oneof riccontrol_failure_ies {
+        RiccontrolFailureIes001 instance001 = 1;
+        RiccontrolFailureIes002 instance002 = 2;
+        RiccontrolFailureIes003 instance003 = 3;
+        RiccontrolFailureIes004 instance004 = 4;
+        RiccontrolFailureIes005 instance005 = 5;
+    }
+    message RiccontrolFailureIes001 {
+        RicrequestId value = 1;
+    };
+
+    message RiccontrolFailureIes002 {
+        RanfunctionId value = 1;
+    };
+
+    message RiccontrolFailureIes003 {
+        RiccallProcessId value = 1;
+    };
+
+    message RiccontrolFailureIes004 {
+        Cause value = 1;
+    };
+
+    message RiccontrolFailureIes005 {
+        RiccontrolOutcome value = 1;
+    };
+
+};
+
+// sequence from e2ap-v01.00.00.asn:609
+message ErrorIndication {
+    ProtocolIeContainer protocol_ies = 1;
+};
+
+// concrete instance(s) of class E2AP-PROTOCOL-IES from e2ap-v01.00.00.asn:613
+message ErrorIndicationIes {
+    oneof error_indication_ies {
+        ErrorIndicationIes001 instance001 = 1;
+        ErrorIndicationIes002 instance002 = 2;
+        ErrorIndicationIes003 instance003 = 3;
+        ErrorIndicationIes004 instance004 = 4;
+    }
+    message ErrorIndicationIes001 {
+        RicrequestId value = 1;
+    };
+
+    message ErrorIndicationIes002 {
+        RanfunctionId value = 1;
+    };
+
+    message ErrorIndicationIes003 {
+        Cause value = 1;
+    };
+
+    message ErrorIndicationIes004 {
+        CriticalityDiagnostics value = 1;
+    };
+
+};
+
+// sequence from e2ap-v01.00.00.asn:633
+message E2setupRequest {
+    ProtocolIeContainer protocol_ies = 1;
+};
+
+// concrete instance(s) of class E2AP-PROTOCOL-IES from e2ap-v01.00.00.asn:637
+message E2setupRequestIes {
+    oneof e2setup_request_ies {
+        E2setupRequestIes001 instance001 = 1;
+        E2setupRequestIes002 instance002 = 2;
+    }
+    message E2setupRequestIes001 {
+        GlobalE2nodeId value = 1;
+    };
+
+    message E2setupRequestIes002 {
+        RanfunctionsList value = 1;
+    };
+
+};
+
+// sequence from e2ap-v01.00.00.asn:650
+message E2setupResponse {
+    ProtocolIeContainer protocol_ies = 1;
+};
+
+// concrete instance(s) of class E2AP-PROTOCOL-IES from e2ap-v01.00.00.asn:654
+message E2setupResponseIes {
+    oneof e2setup_response_ies {
+        E2setupResponseIes001 instance001 = 1;
+        E2setupResponseIes002 instance002 = 2;
+        E2setupResponseIes003 instance003 = 3;
+    }
+    message E2setupResponseIes001 {
+        GlobalRicId value = 1;
+    };
+
+    message E2setupResponseIes002 {
+        RanfunctionsIdList value = 1;
+    };
+
+    message E2setupResponseIes003 {
+        RanfunctionsIdcauseList value = 1;
+    };
+
+};
+
+// sequence from e2ap-v01.00.00.asn:668
+message E2setupFailure {
+    ProtocolIeContainer protocol_ies = 1;
+};
+
+// concrete instance(s) of class E2AP-PROTOCOL-IES from e2ap-v01.00.00.asn:672
+message E2setupFailureIes {
+    oneof e2setup_failure_ies {
+        E2setupFailureIes001 instance001 = 1;
+        E2setupFailureIes002 instance002 = 2;
+        E2setupFailureIes003 instance003 = 3;
+    }
+    message E2setupFailureIes001 {
+        Cause value = 1;
+    };
+
+    message E2setupFailureIes002 {
+        TimeToWait value = 1;
+    };
+
+    message E2setupFailureIes003 {
+        CriticalityDiagnostics value = 1;
+    };
+
+};
+
+// sequence from e2ap-v01.00.00.asn:692
+message ResetRequest {
+    ProtocolIeContainer protocol_ies = 1;
+};
+
+// concrete instance(s) of class E2AP-PROTOCOL-IES from e2ap-v01.00.00.asn:696
+message ResetRequestIes {
+};
+
+// sequence from e2ap-v01.00.00.asn:708
+message ResetResponse {
+    ProtocolIeContainer protocol_ies = 1;
+};
+
+// concrete instance(s) of class E2AP-PROTOCOL-IES from e2ap-v01.00.00.asn:712
+message ResetResponseIes {
+};
+
+// sequence from e2ap-v01.00.00.asn:728
+message RicserviceUpdate {
+    ProtocolIeContainer protocol_ies = 1;
+};
+
+// concrete instance(s) of class E2AP-PROTOCOL-IES from e2ap-v01.00.00.asn:732
+message RicserviceUpdateIes {
+    oneof ricservice_update_ies {
+        RicserviceUpdateIes001 instance001 = 1;
+        RicserviceUpdateIes002 instance002 = 2;
+        RicserviceUpdateIes003 instance003 = 3;
+    }
+    message RicserviceUpdateIes001 {
+        RanfunctionsList value = 1;
+    };
+
+    message RicserviceUpdateIes002 {
+        RanfunctionsList value = 1;
+    };
+
+    message RicserviceUpdateIes003 {
+        RanfunctionsIdList value = 1;
+    };
+
+};
+
+// sequence from e2ap-v01.00.00.asn:739
+message RanfunctionsList {
+    repeated ProtocolIeSingleContainer value = 1;
+};
+
+// concrete instance(s) of class E2AP-PROTOCOL-IES from e2ap-v01.00.00.asn:741
+message RanfunctionItemIes {
+};
+
+// sequence from e2ap-v01.00.00.asn:748
+message RanfunctionItem {
+    RanfunctionId ran_function_id = 1;
+    RanfunctionDefinition ran_function_definition = 2;
+    RanfunctionRevision ran_function_revision = 3;
+};
+
+// sequence from e2ap-v01.00.00.asn:754
+message RanfunctionsIdList {
+    repeated ProtocolIeSingleContainer value = 1;
+};
+
+// concrete instance(s) of class E2AP-PROTOCOL-IES from e2ap-v01.00.00.asn:756
+message RanfunctionIdItemIes {
+};
+
+// sequence from e2ap-v01.00.00.asn:762
+message RanfunctionIdItem {
+    RanfunctionId ran_function_id = 1;
+    RanfunctionRevision ran_function_revision = 2;
+};
+
+// sequence from e2ap-v01.00.00.asn:773
+message RicserviceUpdateAcknowledge {
+    ProtocolIeContainer protocol_ies = 1;
+};
+
+// concrete instance(s) of class E2AP-PROTOCOL-IES from e2ap-v01.00.00.asn:777
+message RicserviceUpdateAcknowledgeIes {
+    oneof ricservice_update_acknowledge_ies {
+        RicserviceUpdateAcknowledgeIes001 instance001 = 1;
+        RicserviceUpdateAcknowledgeIes002 instance002 = 2;
+    }
+    message RicserviceUpdateAcknowledgeIes001 {
+        RanfunctionsIdList value = 1;
+    };
+
+    message RicserviceUpdateAcknowledgeIes002 {
+        RanfunctionsIdcauseList value = 1;
+    };
+
+};
+
+// sequence from e2ap-v01.00.00.asn:783
+message RanfunctionsIdcauseList {
+    repeated ProtocolIeSingleContainer value = 1;
+};
+
+// concrete instance(s) of class E2AP-PROTOCOL-IES from e2ap-v01.00.00.asn:785
+message RanfunctionIdcauseItemIes {
+};
+
+// sequence from e2ap-v01.00.00.asn:792
+message RanfunctionIdcauseItem {
+    RanfunctionId ran_function_id = 1;
+    Cause cause = 2;
+};
+
+// sequence from e2ap-v01.00.00.asn:804
+message RicserviceUpdateFailure {
+    ProtocolIeContainer protocol_ies = 1;
+};
+
+// concrete instance(s) of class E2AP-PROTOCOL-IES from e2ap-v01.00.00.asn:808
+message RicserviceUpdateFailureIes {
+    oneof ricservice_update_failure_ies {
+        RicserviceUpdateFailureIes001 instance001 = 1;
+        RicserviceUpdateFailureIes002 instance002 = 2;
+        RicserviceUpdateFailureIes003 instance003 = 3;
+    }
+    message RicserviceUpdateFailureIes001 {
+        RanfunctionsIdcauseList value = 1;
+    };
+
+    message RicserviceUpdateFailureIes002 {
+        TimeToWait value = 1;
+    };
+
+    message RicserviceUpdateFailureIes003 {
+        CriticalityDiagnostics value = 1;
+    };
+
+};
+
+// sequence from e2ap-v01.00.00.asn:826
+message RicserviceQuery {
+    ProtocolIeContainer protocol_ies = 1;
+};
+
+// concrete instance(s) of class E2AP-PROTOCOL-IES from e2ap-v01.00.00.asn:830
+message RicserviceQueryIes {
+};

--- a/api/e2ap_v01_00_00_asn/v1/e2ap-pdu-descriptions.proto
+++ b/api/e2ap_v01_00_00_asn/v1/e2ap-pdu-descriptions.proto
@@ -1,0 +1,290 @@
+////////////////////// e2ap-pdu-descriptions.proto //////////////////////
+// Protobuf generated from /e2ap-v01.00.00.asn by asn1c-0.9.29
+// E2AP-PDU-Descriptions { iso(1) identified-organization(3) dod(6) internet(1) private(4) enterprise(1) 53148 e2(1) version1(1) e2ap(1) e2ap-PDU-Descriptions(0) }
+
+syntax = "proto3";
+
+package e2ap_v01_00_00_asn.v1;
+
+import "e2ap_v01_00_00_asn/v1/e2ap-commondatatypes.proto";
+import "e2ap_v01_00_00_asn/v1/e2ap-pdu-contents.proto";
+import "e2ap_v01_00_00_asn/v1/e2ap-constants.proto";
+import "validate/v1/validate.proto";
+
+// sequence from e2ap-v01.00.00.asn:90
+message E2ApPdu {
+    // choice from e2ap-v01.00.00.asn:90
+    oneof e2_ap_pdu {
+        InitiatingMessage initiating_message = 1;
+        SuccessfulOutcome successful_outcome = 2;
+        UnsuccessfulOutcome unsuccessful_outcome = 3;
+    }
+};
+
+// sequence from e2ap-v01.00.00.asn:97
+message InitiatingMessage {
+    E2ApElementaryProcedures procedure_code = 1;
+    @procedureCode criticality = 2;
+    @procedureCode value = 3;
+};
+
+// sequence from e2ap-v01.00.00.asn:103
+message SuccessfulOutcome {
+    E2ApElementaryProcedures procedure_code = 1;
+    @procedureCode criticality = 2;
+    @procedureCode value = 3;
+};
+
+// sequence from e2ap-v01.00.00.asn:109
+message UnsuccessfulOutcome {
+    E2ApElementaryProcedures procedure_code = 1;
+    @procedureCode criticality = 2;
+    @procedureCode value = 3;
+};
+
+// concrete instance(s) of class E2AP-ELEMENTARY-PROCEDURE from e2ap-v01.00.00.asn:120
+message E2ApElementaryProcedures {
+    oneof e2_ap_elementary_procedures {
+        E2ApElementaryProcedures001 instance001 = 1;
+        E2ApElementaryProcedures002 instance002 = 2;
+        E2ApElementaryProcedures003 instance003 = 3;
+        E2ApElementaryProcedures004 instance004 = 4;
+        E2ApElementaryProcedures005 instance005 = 5;
+        E2ApElementaryProcedures006 instance006 = 6;
+        E2ApElementaryProcedures007 instance007 = 7;
+        E2ApElementaryProcedures008 instance008 = 8;
+        E2ApElementaryProcedures009 instance009 = 9;
+    }
+    message E2ApElementaryProcedures001 {
+        RicsubscriptionRequest initiating_message = 1;
+        RicsubscriptionResponse successful_outcome = 2;
+        RicsubscriptionFailure unsuccessful_outcome = 3;
+        IdRicsubscription procedure_code = 4;
+        Reject criticality = 5;
+    };
+
+    message E2ApElementaryProcedures002 {
+        RicsubscriptionDeleteRequest initiating_message = 1;
+        RicsubscriptionDeleteResponse successful_outcome = 2;
+        RicsubscriptionDeleteFailure unsuccessful_outcome = 3;
+        IdRicsubscriptionDelete procedure_code = 4;
+        Reject criticality = 5;
+    };
+
+    message E2ApElementaryProcedures003 {
+        RicserviceUpdate initiating_message = 1;
+        RicserviceUpdateAcknowledge successful_outcome = 2;
+        RicserviceUpdateFailure unsuccessful_outcome = 3;
+        IdRicserviceUpdate procedure_code = 4;
+        Reject criticality = 5;
+    };
+
+    message E2ApElementaryProcedures004 {
+        RiccontrolRequest initiating_message = 1;
+        RiccontrolAcknowledge successful_outcome = 2;
+        RiccontrolFailure unsuccessful_outcome = 3;
+        IdRiccontrol procedure_code = 4;
+        Reject criticality = 5;
+    };
+
+    message E2ApElementaryProcedures005 {
+        E2setupRequest initiating_message = 1;
+        E2setupResponse successful_outcome = 2;
+        E2setupFailure unsuccessful_outcome = 3;
+        IdE2setup procedure_code = 4;
+        Reject criticality = 5;
+    };
+
+    message E2ApElementaryProcedures006 {
+        ResetRequest initiating_message = 1;
+        ResetResponse successful_outcome = 2;
+         unsuccessful_outcome = 3;
+        IdReset procedure_code = 4;
+        Reject criticality = 5;
+    };
+
+    message E2ApElementaryProcedures007 {
+        Ricindication initiating_message = 1;
+         successful_outcome = 2;
+         unsuccessful_outcome = 3;
+        IdRicindication procedure_code = 4;
+        Ignore criticality = 5;
+    };
+
+    message E2ApElementaryProcedures008 {
+        RicserviceQuery initiating_message = 1;
+         successful_outcome = 2;
+         unsuccessful_outcome = 3;
+        IdRicserviceQuery procedure_code = 4;
+        Ignore criticality = 5;
+    };
+
+    message E2ApElementaryProcedures009 {
+        ErrorIndication initiating_message = 1;
+         successful_outcome = 2;
+         unsuccessful_outcome = 3;
+        IdErrorIndication procedure_code = 4;
+        Ignore criticality = 5;
+    };
+
+};
+
+// concrete instance(s) of class E2AP-ELEMENTARY-PROCEDURE from e2ap-v01.00.00.asn:126
+message E2ApElementaryProceduresClass1 {
+    oneof e2_ap_elementary_procedures_class_1 {
+        E2ApElementaryProceduresClass1001 instance001 = 1;
+        E2ApElementaryProceduresClass1002 instance002 = 2;
+        E2ApElementaryProceduresClass1003 instance003 = 3;
+        E2ApElementaryProceduresClass1004 instance004 = 4;
+        E2ApElementaryProceduresClass1005 instance005 = 5;
+        E2ApElementaryProceduresClass1006 instance006 = 6;
+    }
+    message E2ApElementaryProceduresClass1001 {
+        RicsubscriptionRequest initiating_message = 1;
+        RicsubscriptionResponse successful_outcome = 2;
+        RicsubscriptionFailure unsuccessful_outcome = 3;
+        IdRicsubscription procedure_code = 4;
+        Reject criticality = 5;
+    };
+
+    message E2ApElementaryProceduresClass1002 {
+        RicsubscriptionDeleteRequest initiating_message = 1;
+        RicsubscriptionDeleteResponse successful_outcome = 2;
+        RicsubscriptionDeleteFailure unsuccessful_outcome = 3;
+        IdRicsubscriptionDelete procedure_code = 4;
+        Reject criticality = 5;
+    };
+
+    message E2ApElementaryProceduresClass1003 {
+        RicserviceUpdate initiating_message = 1;
+        RicserviceUpdateAcknowledge successful_outcome = 2;
+        RicserviceUpdateFailure unsuccessful_outcome = 3;
+        IdRicserviceUpdate procedure_code = 4;
+        Reject criticality = 5;
+    };
+
+    message E2ApElementaryProceduresClass1004 {
+        RiccontrolRequest initiating_message = 1;
+        RiccontrolAcknowledge successful_outcome = 2;
+        RiccontrolFailure unsuccessful_outcome = 3;
+        IdRiccontrol procedure_code = 4;
+        Reject criticality = 5;
+    };
+
+    message E2ApElementaryProceduresClass1005 {
+        E2setupRequest initiating_message = 1;
+        E2setupResponse successful_outcome = 2;
+        E2setupFailure unsuccessful_outcome = 3;
+        IdE2setup procedure_code = 4;
+        Reject criticality = 5;
+    };
+
+    message E2ApElementaryProceduresClass1006 {
+        ResetRequest initiating_message = 1;
+        ResetResponse successful_outcome = 2;
+        IdReset procedure_code = 3;
+        Reject criticality = 4;
+    };
+
+};
+
+// concrete instance(s) of class E2AP-ELEMENTARY-PROCEDURE from e2ap-v01.00.00.asn:136
+message E2ApElementaryProceduresClass2 {
+    oneof e2_ap_elementary_procedures_class_2 {
+        E2ApElementaryProceduresClass2001 instance001 = 1;
+        E2ApElementaryProceduresClass2002 instance002 = 2;
+        E2ApElementaryProceduresClass2003 instance003 = 3;
+    }
+    message E2ApElementaryProceduresClass2001 {
+        Ricindication initiating_message = 1;
+        IdRicindication procedure_code = 2;
+        Ignore criticality = 3;
+    };
+
+    message E2ApElementaryProceduresClass2002 {
+        RicserviceQuery initiating_message = 1;
+        IdRicserviceQuery procedure_code = 2;
+        Ignore criticality = 3;
+    };
+
+    message E2ApElementaryProceduresClass2003 {
+        ErrorIndication initiating_message = 1;
+        IdErrorIndication procedure_code = 2;
+        Ignore criticality = 3;
+    };
+
+};
+
+// concrete instance(s) of class E2AP-ELEMENTARY-PROCEDURE from e2ap-v01.00.00.asn:149
+message E2setup {
+    E2setupRequest initiating_message = 1;
+    E2setupResponse successful_outcome = 2;
+    E2setupFailure unsuccessful_outcome = 3;
+    IdE2setup procedure_code = 4;
+    Reject criticality = 5;
+};
+
+// concrete instance(s) of class E2AP-ELEMENTARY-PROCEDURE from e2ap-v01.00.00.asn:157
+message ErrorIndication {
+    ErrorIndication initiating_message = 1;
+    IdErrorIndication procedure_code = 2;
+    Ignore criticality = 3;
+};
+
+// concrete instance(s) of class E2AP-ELEMENTARY-PROCEDURE from e2ap-v01.00.00.asn:163
+message Reset {
+    ResetRequest initiating_message = 1;
+    ResetResponse successful_outcome = 2;
+    IdReset procedure_code = 3;
+    Reject criticality = 4;
+};
+
+// concrete instance(s) of class E2AP-ELEMENTARY-PROCEDURE from e2ap-v01.00.00.asn:170
+message RicControl {
+    RiccontrolRequest initiating_message = 1;
+    RiccontrolAcknowledge successful_outcome = 2;
+    RiccontrolFailure unsuccessful_outcome = 3;
+    IdRiccontrol procedure_code = 4;
+    Reject criticality = 5;
+};
+
+// concrete instance(s) of class E2AP-ELEMENTARY-PROCEDURE from e2ap-v01.00.00.asn:178
+message RicIndication {
+    Ricindication initiating_message = 1;
+    IdRicindication procedure_code = 2;
+    Ignore criticality = 3;
+};
+
+// concrete instance(s) of class E2AP-ELEMENTARY-PROCEDURE from e2ap-v01.00.00.asn:184
+message RicServiceQuery {
+    RicserviceQuery initiating_message = 1;
+    IdRicserviceQuery procedure_code = 2;
+    Ignore criticality = 3;
+};
+
+// concrete instance(s) of class E2AP-ELEMENTARY-PROCEDURE from e2ap-v01.00.00.asn:190
+message RicServiceUpdate {
+    RicserviceUpdate initiating_message = 1;
+    RicserviceUpdateAcknowledge successful_outcome = 2;
+    RicserviceUpdateFailure unsuccessful_outcome = 3;
+    IdRicserviceUpdate procedure_code = 4;
+    Reject criticality = 5;
+};
+
+// concrete instance(s) of class E2AP-ELEMENTARY-PROCEDURE from e2ap-v01.00.00.asn:198
+message RicSubscription {
+    RicsubscriptionRequest initiating_message = 1;
+    RicsubscriptionResponse successful_outcome = 2;
+    RicsubscriptionFailure unsuccessful_outcome = 3;
+    IdRicsubscription procedure_code = 4;
+    Reject criticality = 5;
+};
+
+// concrete instance(s) of class E2AP-ELEMENTARY-PROCEDURE from e2ap-v01.00.00.asn:206
+message RicSubscriptionDelete {
+    RicsubscriptionDeleteRequest initiating_message = 1;
+    RicsubscriptionDeleteResponse successful_outcome = 2;
+    RicsubscriptionDeleteFailure unsuccessful_outcome = 3;
+    IdRicsubscriptionDelete procedure_code = 4;
+    Reject criticality = 5;
+};

--- a/api/validate/v1/validate.proto
+++ b/api/validate/v1/validate.proto
@@ -1,0 +1,797 @@
+syntax = "proto2";
+package validate.v1;
+
+option go_package = "github.com/envoyproxy/protoc-gen-validate/validate";
+option java_package = "io.envoyproxy.pgv.validate";
+
+import "google/protobuf/descriptor.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
+
+// Validation rules applied at the message level
+extend google.protobuf.MessageOptions {
+    // Disabled nullifies any validation rules for this message, including any
+    // message fields associated with it that do support validation.
+    optional bool disabled = 1071;
+}
+
+// Validation rules applied at the oneof level
+extend google.protobuf.OneofOptions {
+    // Required ensures that exactly one the field options in a oneof is set;
+    // validation fails if no fields in the oneof are set.
+    optional bool required = 1071;
+}
+
+// Validation rules applied at the field level
+extend google.protobuf.FieldOptions {
+    // Rules specify the validations to be performed on this field. By default,
+    // no validation is performed against a field.
+    optional FieldRules rules = 1071;
+}
+
+// FieldRules encapsulates the rules for each type of field. Depending on the
+// field, the correct set should be used to ensure proper validations.
+message FieldRules {
+    optional MessageRules message = 17;
+    oneof type {
+        // Scalar Field Types
+        FloatRules    float    = 1;
+        DoubleRules   double   = 2;
+        Int32Rules    int32    = 3;
+        Int64Rules    int64    = 4;
+        UInt32Rules   uint32   = 5;
+        UInt64Rules   uint64   = 6;
+        SInt32Rules   sint32   = 7;
+        SInt64Rules   sint64   = 8;
+        Fixed32Rules  fixed32  = 9;
+        Fixed64Rules  fixed64  = 10;
+        SFixed32Rules sfixed32 = 11;
+        SFixed64Rules sfixed64 = 12;
+        BoolRules     bool     = 13;
+        StringRules   string   = 14;
+        BytesRules    bytes    = 15;
+
+        // Complex Field Types
+        EnumRules     enum     = 16;
+        RepeatedRules repeated = 18;
+        MapRules      map      = 19;
+
+        // Well-Known Field Types
+        AnyRules       any       = 20;
+        DurationRules  duration  = 21;
+        TimestampRules timestamp = 22;
+    }
+}
+
+// FloatRules describes the constraints applied to `float` values
+message FloatRules {
+    // Const specifies that this field must be exactly the specified value
+    optional float const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional float lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional float lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional float gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional float gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated float in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated float not_in = 7;
+}
+
+// DoubleRules describes the constraints applied to `double` values
+message DoubleRules {
+    // Const specifies that this field must be exactly the specified value
+    optional double const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional double lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional double lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional double gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional double gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated double in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated double not_in = 7;
+}
+
+// Int32Rules describes the constraints applied to `int32` values
+message Int32Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional int32 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional int32 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional int32 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional int32 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional int32 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated int32 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated int32 not_in = 7;
+}
+
+// Int64Rules describes the constraints applied to `int64` values
+message Int64Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional int64 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional int64 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional int64 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional int64 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional int64 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated int64 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated int64 not_in = 7;
+}
+
+// UInt32Rules describes the constraints applied to `uint32` values
+message UInt32Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional uint32 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional uint32 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional uint32 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional uint32 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional uint32 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated uint32 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated uint32 not_in = 7;
+}
+
+// UInt64Rules describes the constraints applied to `uint64` values
+message UInt64Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional uint64 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional uint64 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional uint64 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional uint64 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional uint64 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated uint64 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated uint64 not_in = 7;
+}
+
+// SInt32Rules describes the constraints applied to `sint32` values
+message SInt32Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional sint32 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional sint32 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional sint32 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional sint32 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional sint32 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated sint32 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated sint32 not_in = 7;
+}
+
+// SInt64Rules describes the constraints applied to `sint64` values
+message SInt64Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional sint64 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional sint64 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional sint64 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional sint64 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional sint64 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated sint64 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated sint64 not_in = 7;
+}
+
+// Fixed32Rules describes the constraints applied to `fixed32` values
+message Fixed32Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional fixed32 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional fixed32 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional fixed32 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional fixed32 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional fixed32 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated fixed32 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated fixed32 not_in = 7;
+}
+
+// Fixed64Rules describes the constraints applied to `fixed64` values
+message Fixed64Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional fixed64 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional fixed64 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional fixed64 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional fixed64 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional fixed64 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated fixed64 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated fixed64 not_in = 7;
+}
+
+// SFixed32Rules describes the constraints applied to `sfixed32` values
+message SFixed32Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional sfixed32 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional sfixed32 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional sfixed32 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional sfixed32 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional sfixed32 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated sfixed32 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated sfixed32 not_in = 7;
+}
+
+// SFixed64Rules describes the constraints applied to `sfixed64` values
+message SFixed64Rules {
+    // Const specifies that this field must be exactly the specified value
+    optional sfixed64 const = 1;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional sfixed64 lt = 2;
+
+    // Lte specifies that this field must be less than or equal to the
+    // specified value, inclusive
+    optional sfixed64 lte = 3;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive. If the value of Gt is larger than a specified Lt or Lte, the
+    // range is reversed.
+    optional sfixed64 gt = 4;
+
+    // Gte specifies that this field must be greater than or equal to the
+    // specified value, inclusive. If the value of Gte is larger than a
+    // specified Lt or Lte, the range is reversed.
+    optional sfixed64 gte = 5;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated sfixed64 in = 6;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated sfixed64 not_in = 7;
+}
+
+// BoolRules describes the constraints applied to `bool` values
+message BoolRules {
+    // Const specifies that this field must be exactly the specified value
+    optional bool const = 1;
+}
+
+// StringRules describe the constraints applied to `string` values
+message StringRules {
+    // Const specifies that this field must be exactly the specified value
+    optional string const = 1;
+
+    // Len specifies that this field must be the specified number of
+    // characters (Unicode code points). Note that the number of
+    // characters may differ from the number of bytes in the string.
+    optional uint64 len = 19;
+
+    // MinLen specifies that this field must be the specified number of
+    // characters (Unicode code points) at a minimum. Note that the number of
+    // characters may differ from the number of bytes in the string.
+    optional uint64 min_len = 2;
+
+    // MaxLen specifies that this field must be the specified number of
+    // characters (Unicode code points) at a maximum. Note that the number of
+    // characters may differ from the number of bytes in the string.
+    optional uint64 max_len = 3;
+
+    // LenBytes specifies that this field must be the specified number of bytes
+    // at a minimum
+    optional uint64 len_bytes = 20;
+
+    // MinBytes specifies that this field must be the specified number of bytes
+    // at a minimum
+    optional uint64 min_bytes = 4;
+
+    // MaxBytes specifies that this field must be the specified number of bytes
+    // at a maximum
+    optional uint64 max_bytes = 5;
+
+    // Pattern specifes that this field must match against the specified
+    // regular expression (RE2 syntax). The included expression should elide
+    // any delimiters.
+    optional string pattern  = 6;
+
+    // Prefix specifies that this field must have the specified substring at
+    // the beginning of the string.
+    optional string prefix   = 7;
+
+    // Suffix specifies that this field must have the specified substring at
+    // the end of the string.
+    optional string suffix   = 8;
+
+    // Contains specifies that this field must have the specified substring
+    // anywhere in the string.
+    optional string contains = 9;
+
+    // NotContains specifies that this field cannot have the specified substring
+    // anywhere in the string.
+    optional string not_contains = 23;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated string in     = 10;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated string not_in = 11;
+
+    // WellKnown rules provide advanced constraints against common string
+    // patterns
+    oneof well_known {
+        // Email specifies that the field must be a valid email address as
+        // defined by RFC 5322
+        bool email    = 12;
+
+        // Hostname specifies that the field must be a valid hostname as
+        // defined by RFC 1034. This constraint does not support
+        // internationalized domain names (IDNs).
+        bool hostname = 13;
+
+        // Ip specifies that the field must be a valid IP (v4 or v6) address.
+        // Valid IPv6 addresses should not include surrounding square brackets.
+        bool ip       = 14;
+
+        // Ipv4 specifies that the field must be a valid IPv4 address.
+        bool ipv4     = 15;
+
+        // Ipv6 specifies that the field must be a valid IPv6 address. Valid
+        // IPv6 addresses should not include surrounding square brackets.
+        bool ipv6     = 16;
+
+        // Uri specifies that the field must be a valid, absolute URI as defined
+        // by RFC 3986
+        bool uri      = 17;
+
+        // UriRef specifies that the field must be a valid URI as defined by RFC
+        // 3986 and may be relative or absolute.
+        bool uri_ref  = 18;
+
+        // Address specifies that the field must be either a valid hostname as
+        // defined by RFC 1034 (which does not support internationalized domain
+        // names or IDNs), or it can be a valid IP (v4 or v6).
+        bool address  = 21;
+
+        // Uuid specifies that the field must be a valid UUID as defined by
+        // RFC 4122
+        bool uuid     = 22;
+
+        // WellKnownRegex specifies a common well known pattern defined as a regex.
+        KnownRegex well_known_regex = 24;
+    }
+
+  // This applies to regexes HTTP_HEADER_NAME and HTTP_HEADER_VALUE to enable
+  // strict header validation.
+  // By default, this is true, and HTTP header validations are RFC-compliant.
+  // Setting to false will enable a looser validations that only disallows
+  // \r\n\0 characters, which can be used to bypass header matching rules.
+  optional bool strict = 25 [default = true];
+}
+
+// WellKnownRegex contain some well-known patterns.
+enum KnownRegex {
+  KNOWN_REGEX_UNKNOWN = 0;
+
+  // HTTP header name as defined by RFC 7230.
+  KNOWN_REGEX_HTTP_HEADER_NAME = 1;
+
+  // HTTP header value as defined by RFC 7230.
+  KNOWN_REGEX_HTTP_HEADER_VALUE = 2;
+}
+
+// BytesRules describe the constraints applied to `bytes` values
+message BytesRules {
+    // Const specifies that this field must be exactly the specified value
+    optional bytes const = 1;
+
+    // Len specifies that this field must be the specified number of bytes
+    optional uint64 len = 13;
+
+    // MinLen specifies that this field must be the specified number of bytes
+    // at a minimum
+    optional uint64 min_len = 2;
+
+    // MaxLen specifies that this field must be the specified number of bytes
+    // at a maximum
+    optional uint64 max_len = 3;
+
+    // Pattern specifes that this field must match against the specified
+    // regular expression (RE2 syntax). The included expression should elide
+    // any delimiters.
+    optional string pattern  = 4;
+
+    // Prefix specifies that this field must have the specified bytes at the
+    // beginning of the string.
+    optional bytes  prefix   = 5;
+
+    // Suffix specifies that this field must have the specified bytes at the
+    // end of the string.
+    optional bytes  suffix   = 6;
+
+    // Contains specifies that this field must have the specified bytes
+    // anywhere in the string.
+    optional bytes  contains = 7;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated bytes in     = 8;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated bytes not_in = 9;
+
+    // WellKnown rules provide advanced constraints against common byte
+    // patterns
+    oneof well_known {
+        // Ip specifies that the field must be a valid IP (v4 or v6) address in
+        // byte format
+        bool ip   = 10;
+
+        // Ipv4 specifies that the field must be a valid IPv4 address in byte
+        // format
+        bool ipv4 = 11;
+
+        // Ipv6 specifies that the field must be a valid IPv6 address in byte
+        // format
+        bool ipv6 = 12;
+    }
+}
+
+// EnumRules describe the constraints applied to enum values
+message EnumRules {
+    // Const specifies that this field must be exactly the specified value
+    optional int32 const        = 1;
+
+    // DefinedOnly specifies that this field must be only one of the defined
+    // values for this enum, failing on any undefined value.
+    optional bool  defined_only = 2;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated int32 in           = 3;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated int32 not_in       = 4;
+}
+
+// MessageRules describe the constraints applied to embedded message values.
+// For message-type fields, validation is performed recursively.
+message MessageRules {
+    // Skip specifies that the validation rules of this field should not be
+    // evaluated
+    optional bool skip     = 1;
+
+    // Required specifies that this field must be set
+    optional bool required = 2;
+}
+
+// RepeatedRules describe the constraints applied to `repeated` values
+message RepeatedRules {
+    // MinItems specifies that this field must have the specified number of
+    // items at a minimum
+    optional uint64 min_items = 1;
+
+    // MaxItems specifies that this field must have the specified number of
+    // items at a maximum
+    optional uint64 max_items = 2;
+
+    // Unique specifies that all elements in this field must be unique. This
+    // contraint is only applicable to scalar and enum types (messages are not
+    // supported).
+    optional bool   unique    = 3;
+
+    // Items specifies the contraints to be applied to each item in the field.
+    // Repeated message fields will still execute validation against each item
+    // unless skip is specified here.
+    optional FieldRules items = 4;
+}
+
+// MapRules describe the constraints applied to `map` values
+message MapRules {
+    // MinPairs specifies that this field must have the specified number of
+    // KVs at a minimum
+    optional uint64 min_pairs = 1;
+
+    // MaxPairs specifies that this field must have the specified number of
+    // KVs at a maximum
+    optional uint64 max_pairs = 2;
+
+    // NoSparse specifies values in this field cannot be unset. This only
+    // applies to map's with message value types.
+    optional bool no_sparse = 3;
+
+    // Keys specifies the constraints to be applied to each key in the field.
+    optional FieldRules keys   = 4;
+
+    // Values specifies the constraints to be applied to the value of each key
+    // in the field. Message values will still have their validations evaluated
+    // unless skip is specified here.
+    optional FieldRules values = 5;
+}
+
+// AnyRules describe constraints applied exclusively to the
+// `google.protobuf.Any` well-known type
+message AnyRules {
+    // Required specifies that this field must be set
+    optional bool required = 1;
+
+    // In specifies that this field's `type_url` must be equal to one of the
+    // specified values.
+    repeated string in     = 2;
+
+    // NotIn specifies that this field's `type_url` must not be equal to any of
+    // the specified values.
+    repeated string not_in = 3;
+}
+
+// DurationRules describe the constraints applied exclusively to the
+// `google.protobuf.Duration` well-known type
+message DurationRules {
+    // Required specifies that this field must be set
+    optional bool required = 1;
+
+    // Const specifies that this field must be exactly the specified value
+    optional google.protobuf.Duration const = 2;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional google.protobuf.Duration lt = 3;
+
+    // Lt specifies that this field must be less than the specified value,
+    // inclusive
+    optional google.protobuf.Duration lte = 4;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive
+    optional google.protobuf.Duration gt = 5;
+
+    // Gte specifies that this field must be greater than the specified value,
+    // inclusive
+    optional google.protobuf.Duration gte = 6;
+
+    // In specifies that this field must be equal to one of the specified
+    // values
+    repeated google.protobuf.Duration in = 7;
+
+    // NotIn specifies that this field cannot be equal to one of the specified
+    // values
+    repeated google.protobuf.Duration not_in = 8;
+}
+
+// TimestampRules describe the constraints applied exclusively to the
+// `google.protobuf.Timestamp` well-known type
+message TimestampRules {
+    // Required specifies that this field must be set
+    optional bool required = 1;
+
+    // Const specifies that this field must be exactly the specified value
+    optional google.protobuf.Timestamp const = 2;
+
+    // Lt specifies that this field must be less than the specified value,
+    // exclusive
+    optional google.protobuf.Timestamp lt = 3;
+
+    // Lte specifies that this field must be less than the specified value,
+    // inclusive
+    optional google.protobuf.Timestamp lte = 4;
+
+    // Gt specifies that this field must be greater than the specified value,
+    // exclusive
+    optional google.protobuf.Timestamp gt = 5;
+
+    // Gte specifies that this field must be greater than the specified value,
+    // inclusive
+    optional google.protobuf.Timestamp gte = 6;
+
+    // LtNow specifies that this must be less than the current time. LtNow
+    // can only be used with the Within rule.
+    optional bool lt_now  = 7;
+
+    // GtNow specifies that this must be greater than the current time. GtNow
+    // can only be used with the Within rule.
+    optional bool gt_now  = 8;
+
+    // Within specifies that this field must be within this duration of the
+    // current time. This constraint can be used alone or with the LtNow and
+    // GtNow rules.
+    optional google.protobuf.Duration within = 9;
+}


### PR DESCRIPTION
This is not finished yet and will not pass "buf lint check" or protoc
compile to Go but just wanted to get something checked in to get the
ball rolling

I will finish it by hand next week, or by more tweaking of the `asn1c` tool.

For comparison the ASN.1 is at https://github.com/onosproject/asn1c/blob/master/examples/e2ap-v01.00.00.asn