### PR TITLE
Add stream abstraction for northbound streams

### DIFF
--- a/pkg/northbound/stream/manager.go
+++ b/pkg/northbound/stream/manager.go
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2020-present Open Networking Foundation <info@opennetworking.org>
+//
+// SPDX-License-Identifier: LicenseRef-ONF-Member-1.0
+
+package stream
+
+import (
+	"context"
+	"fmt"
+	"github.com/onosproject/onos-lib-go/pkg/logging"
+	"io"
+	"sync"
+)
+
+var log = logging.GetLogger("northbound", "stream")
+
+// NewManager creates a new stream manager
+func NewManager() *Manager {
+	mgr := &Manager{
+		streams: make(map[ID]Stream),
+		eventCh: make(chan Stream),
+	}
+	go mgr.processEvents()
+	return mgr
+}
+
+// Manager is a stream manager
+type Manager struct {
+	streams    map[ID]Stream
+	streamsMu  sync.RWMutex
+	watchers   []chan<- Stream
+	watchersMu sync.RWMutex
+	eventCh    chan Stream
+}
+
+func (m *Manager) processEvents() {
+	for stream := range m.eventCh {
+		m.processEvent(stream)
+	}
+}
+
+func (m *Manager) processEvent(stream Stream) {
+	log.Infof("Notifying stream %s", stream.ID())
+	m.watchersMu.RLock()
+	for _, watcher := range m.watchers {
+		watcher <- stream
+	}
+	m.watchersMu.RUnlock()
+}
+
+// Open opens a new stream
+func (m *Manager) Open(ctx context.Context, id ID, ch chan Message) (ReadStream, error) {
+	m.streamsMu.Lock()
+	defer m.streamsMu.Unlock()
+	stream := newChannelStream(ctx, id, ch)
+	m.streams[id] = stream
+	m.eventCh <- stream
+	go func() {
+		<-ctx.Done()
+		m.streamsMu.Lock()
+		delete(m.streams, id)
+		m.streamsMu.Unlock()
+	}()
+	return stream, nil
+}
+
+// Get gets a stream by ID
+func (m *Manager) Get(ctx context.Context, id ID) (WriteStream, error) {
+	m.streamsMu.RLock()
+	defer m.streamsMu.RUnlock()
+	stream, ok := m.streams[id]
+	if !ok {
+		return nil, fmt.Errorf("unknown stream %s", id)
+	}
+	return stream, nil
+}
+
+// Watch watches for streams
+func (m *Manager) Watch(ctx context.Context, ch chan<- Stream) error {
+	m.watchersMu.Lock()
+	m.streamsMu.Lock()
+	m.watchers = append(m.watchers, ch)
+	m.watchersMu.Unlock()
+
+	go func() {
+		for _, stream := range m.streams {
+			ch <- stream
+		}
+		m.streamsMu.Unlock()
+
+		<-ctx.Done()
+		m.watchersMu.Lock()
+		watchers := make([]chan<- Stream, 0, len(m.watchers)-1)
+		for _, watcher := range watchers {
+			if watcher != ch {
+				watchers = append(watchers, watcher)
+			}
+		}
+		m.watchers = watchers
+		m.watchersMu.Unlock()
+	}()
+	return nil
+}
+
+// Close closes the manager
+func (m *Manager) Close() error {
+	close(m.eventCh)
+	return nil
+}
+
+var _ io.Closer = &Manager{}

--- a/pkg/northbound/stream/stream.go
+++ b/pkg/northbound/stream/stream.go
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: 2020-present Open Networking Foundation <info@opennetworking.org>
+//
+// SPDX-License-Identifier: LicenseRef-ONF-Member-1.0
+
+package stream
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+)
+
+// Value creates a new value message
+func Value(id MessageID, payload []byte) Message {
+	return Message{
+		ID:      id,
+		Payload: payload,
+	}
+}
+
+// Error creates a new error message
+func Error(id MessageID, err error) Message {
+	return Message{
+		ID:    id,
+		Error: err,
+	}
+}
+
+// MessageID is a message identifier
+type MessageID uint64
+
+// Message is a stream message
+type Message struct {
+	// ID is the message identifier
+	ID MessageID
+
+	// Payload is the message payload
+	Payload []byte
+
+	// Error is the message error
+	Error error
+}
+
+// ReadStream is a read stream
+type ReadStream interface {
+	// Recv reads a message from the stream
+	Recv() (Message, error)
+
+	// Context returns the stream context
+	Context() context.Context
+}
+
+// WriteStream is a write stream
+type WriteStream interface {
+	io.Closer
+
+	// Send sends a message on the stream
+	Send(message Message) error
+}
+
+// ID is a stream identifier
+type ID string
+
+// Stream is a read/write stream
+type Stream interface {
+	ReadStream
+	WriteStream
+
+	// ID returns the stream identifier
+	ID() ID
+}
+
+// channelReadStream is a channel-based read stream
+type channelReadStream struct {
+	readCh <-chan Message
+	ctx    context.Context
+}
+
+func (s *channelReadStream) Recv() (Message, error) {
+	m, ok := <-s.readCh
+	if !ok {
+		return Message{}, errors.New("ReadStream is closed")
+	}
+	return m, nil
+}
+
+func (s *channelReadStream) Context() context.Context {
+	return s.ctx
+}
+
+var _ ReadStream = &channelReadStream{}
+
+// channelWriteStream is a channel-based write stream
+type channelWriteStream struct {
+	writeCh chan<- Message
+	mu      sync.Mutex
+	closed  bool
+}
+
+func (s *channelWriteStream) Send(message Message) error {
+	failed := false
+	defer func() {
+		if e := recover(); e != nil {
+			failed = true
+		}
+	}()
+	s.writeCh <- message
+	if failed {
+		return errors.New("WriteStream is closed")
+	}
+	return nil
+}
+
+func (s *channelWriteStream) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return errors.New("WriteStream is closed")
+	}
+	close(s.writeCh)
+	s.closed = true
+	return nil
+}
+
+var _ WriteStream = &channelWriteStream{}
+
+func newChannelStream(ctx context.Context, id ID, ch chan Message) Stream {
+	stream := &channelStream{
+		channelReadStream: &channelReadStream{
+			readCh: ch,
+			ctx:    ctx,
+		},
+		channelWriteStream: &channelWriteStream{
+			writeCh: ch,
+		},
+		id: id,
+	}
+	go func() {
+		<-ctx.Done()
+		stream.Close()
+	}()
+	return stream
+}
+
+// channelStream is a channel-based stream
+type channelStream struct {
+	*channelReadStream
+	*channelWriteStream
+	id ID
+}
+
+func (s *channelStream) ID() ID {
+	return s.id
+}
+
+var _ Stream = &channelStream{}


### PR DESCRIPTION
This PR adds a `Stream` abstraction that wraps NB API streams internally. This is used by the subscription broker to propagate indications up to the NB API.