### PR TITLE
Switch southbound to use PER encoding for E2AP messages

### DIFF
--- a/pkg/southbound/e2/channel/manager.go
+++ b/pkg/southbound/e2/channel/manager.go
@@ -87,10 +87,9 @@ func (m *Manager) setup(ctx context.Context, conn net.Conn) (Channel, error) {
 		return nil, err
 	}
 
-	// Decode the E2 request in XER encoding
-	// TODO: E2AP messages are supposed to use PER encoding
+	// Decode the E2 request in PER encoding
 	e2PDUReqBytes := buf[:n]
-	e2PDUReq, err := asn1cgo.XerDecodeE2apPdu(e2PDUReqBytes)
+	e2PDUReq, err := asn1cgo.PerDecodeE2apPdu(e2PDUReqBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -170,9 +169,8 @@ func (m *Manager) setup(ctx context.Context, conn net.Conn) (Channel, error) {
 		return nil, err
 	}
 
-	// Encode the setup response in XER
-	// TODO: E2AP messages are supposed to use PER encoding
-	e2PDURespBytes, err := asn1cgo.XerEncodeE2apPdu(e2PDUResp)
+	// Encode the setup response in PER
+	e2PDURespBytes, err := asn1cgo.PerEncodeE2apPdu(e2PDUResp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/subscription/controller.go
+++ b/pkg/subscription/controller.go
@@ -139,7 +139,7 @@ func (r *Reconciler) reconcileOpenSubscriptionTask(task *subtaskapi.Subscription
 	}
 
 	// Send the subscription request and await a response
-	response, err := channel.SendRecv(request, channelfilter.RicSubscription(ricRequestID), codec.XER)
+	response, err := channel.SendRecv(request, channelfilter.RicSubscription(ricRequestID), codec.PER)
 	if err != nil {
 		return controller.Result{}, err
 	}
@@ -236,7 +236,7 @@ func (r *Reconciler) reconcileCloseSubscriptionTask(task *subtaskapi.Subscriptio
 	}
 
 	// Send the subscription request and await a response
-	response, err := channel.SendRecv(request, channelfilter.RicSubscriptionDelete(ricRequestID.Value), codec.XER)
+	response, err := channel.SendRecv(request, channelfilter.RicSubscriptionDelete(ricRequestID.Value), codec.PER)
 	if err != nil {
 		return controller.Result{}, err
 	}

--- a/pkg/subscription/dispatcher.go
+++ b/pkg/subscription/dispatcher.go
@@ -48,7 +48,7 @@ func (d *Dispatcher) open() error {
 	ricRequestID := &e2apies.RicrequestId{
 		RicInstanceId: config.InstanceID,
 	}
-	indCh := d.channel.Recv(filter.RicIndication(ricRequestID), codec.XER)
+	indCh := d.channel.Recv(filter.RicIndication(ricRequestID), codec.PER)
 	go d.processIndications(indCh)
 	return nil
 }


### PR DESCRIPTION
Switch from XER to PER encoding since the e2sim now supports it.