### PR TITLE
Change 'get connections' to 'list connections' for consistency

### DIFF
--- a/pkg/cli/connections.go
+++ b/pkg/cli/connections.go
@@ -16,17 +16,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func getGetConnectionsCommand() *cobra.Command {
+func getListConnectionsCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "connections",
 		Short: "Get SB connections",
-		RunE:  runConnectionsCommand,
+		RunE:  runListConnectionsCommand,
 	}
 	cmd.Flags().Bool("no-headers", false, "disables output headers")
 	return cmd
 }
 
-func runConnectionsCommand(cmd *cobra.Command, args []string) error {
+func runListConnectionsCommand(cmd *cobra.Command, args []string) error {
 	noHeaders, _ := cmd.Flags().GetBool("no-headers")
 	conn, err := cli.GetConnection(cmd)
 	if err != nil {

--- a/pkg/cli/crud.go
+++ b/pkg/cli/crud.go
@@ -6,19 +6,12 @@ package cli
 
 import "github.com/spf13/cobra"
 
-func getGetCommand() *cobra.Command {
+func getListCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "get {connections | subscriptions} [args]",
-		Short: "Get E2T resources",
+		Use:   "list {connections | subscriptions} [args]",
+		Short: "List E2T resources",
 	}
-	cmd.AddCommand(getGetConnectionsCommand())
+	cmd.AddCommand(getListConnectionsCommand())
 	return cmd
 }
 
-func getWatchCommand() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "watch {subscriptions} [args]",
-		Short: "Monitor E2T resources",
-	}
-	return cmd
-}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -34,8 +34,7 @@ func GetCommand() *cobra.Command {
 
 	cli.AddConfigFlags(cmd, defaultAddress)
 	cmd.AddCommand(cli.GetConfigCommand())
-	cmd.AddCommand(getGetCommand())
-	cmd.AddCommand(getWatchCommand())
+	cmd.AddCommand(getListCommand())
 	cmd.AddCommand(loglib.GetCommand())
 	return cmd
 }


### PR DESCRIPTION
Make the e2t CLI consistent with the e2sub CLI