### PR TITLE
Support all E2 node IDs in E2 southbound

### DIFF
--- a/pkg/southbound/e2/channel/channel_test.go
+++ b/pkg/southbound/e2/channel/channel_test.go
@@ -43,9 +43,8 @@ func TestChannel(t *testing.T) {
 	}).AnyTimes()
 
 	meta := Metadata{
-		ID:           "test",
-		PlmnID:       "onf",
-		RANFunctions: map[RANFunctionID]RANFunctionMetadata{},
+		ID:     "test",
+		PlmnID: "onf",
 	}
 	channel := newChannel(context.Background(), conn, meta)
 	assert.Equal(t, ID("test"), channel.ID())

--- a/pkg/southbound/e2/channel/metadata.go
+++ b/pkg/southbound/e2/channel/metadata.go
@@ -32,12 +32,4 @@ type Metadata struct {
 
 	// PlmnID is the PLMN identifier
 	PlmnID PlmnID
-
-	// RANFunctions is a map of RAN functions
-	RANFunctions map[RANFunctionID]RANFunctionMetadata
-}
-
-// GetRanFunction gets a RAN function by ID
-func (m Metadata) GetRANFunction(id RANFunctionID) RANFunctionMetadata {
-	return m.RANFunctions[id]
 }


### PR DESCRIPTION
Replaces the current setup handling with the decoder/builder functions. Currently, all RAN functions are accepted.