### PR TITLE
E2AP RicIndication Decode - add new Unit test

### DIFF
--- a/pkg/southbound/e2ap/pdudecoder/ricIndicationDecoder.go
+++ b/pkg/southbound/e2ap/pdudecoder/ricIndicationDecoder.go
@@ -37,11 +37,12 @@ func DecodeRicIndicationPdu(e2apPdu *e2appdudescriptions.E2ApPdu) (
 	}
 	ricActionID := types.RicActionID(ricActionIDIe.GetValue().GetValue())
 
+	var ricCallProcessID *types.RicCallProcessID
 	ricCallProcessIDIe := ricIndication.GetInitiatingMessage().GetProtocolIes().GetE2ApProtocolIes20()
-	if ricCallProcessIDIe == nil {
-		return 0, 0, nil, nil, nil, 0, 0, nil, fmt.Errorf("error E2APpdu does not have id-RICactionID")
+	if ricCallProcessIDIe != nil { // Is optional
+		ricCallProcessIDBytes := types.RicCallProcessID(ricCallProcessIDIe.GetValue().GetValue())
+		ricCallProcessID = &ricCallProcessIDBytes
 	}
-	ricCallProcessID := types.RicCallProcessID(ricCallProcessIDIe.GetValue().GetValue())
 
 	ricIndicationHeaderIe := ricIndication.GetInitiatingMessage().GetProtocolIes().GetE2ApProtocolIes25()
 	if ricIndicationHeaderIe == nil {
@@ -78,6 +79,6 @@ func DecodeRicIndicationPdu(e2apPdu *e2appdudescriptions.E2ApPdu) (
 		}
 	}
 
-	return ranFunctionID, ricActionID, &ricCallProcessID, &ricIndicationHeader,
+	return ranFunctionID, ricActionID, ricCallProcessID, &ricIndicationHeader,
 		&ricIndicationMessage, ricIndicationSn, ricIndicationType, &ricRequestID, nil
 }

--- a/pkg/southbound/e2ap/pdudecoder/ricIndicationDecoder_test.go
+++ b/pkg/southbound/e2ap/pdudecoder/ricIndicationDecoder_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/onosproject/onos-e2t/api/e2ap/v1beta1/e2apies"
 	"github.com/onosproject/onos-e2t/pkg/southbound/e2ap/asn1cgo"
 	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
 	"io/ioutil"
 	"testing"
 )
@@ -28,6 +29,34 @@ func Test_DecodeRicIndicationPdu(t *testing.T) {
 	assert.DeepEqual(t, []byte{'7', '8', '9'}, []byte(*ricCallProcessID))
 	assert.Equal(t, 1, int(ricIndicationSn), "unexpected ricIndicationSn")
 	assert.Equal(t, e2apies.RicindicationType_RICINDICATION_TYPE_INSERT, ricIndicationType, "unexpected ricIndicationType")
+	assert.Assert(t, ricRequest != nil)
+
+}
+
+func Test_DecodeRicIndicationPdu2(t *testing.T) {
+	e2setupRequestXer, err := ioutil.ReadFile("../test/RicIndication2.xml")
+	assert.NilError(t, err, "Unexpected error when loading file")
+	e2apPdu, err := asn1cgo.XerDecodeE2apPdu(e2setupRequestXer)
+	assert.NilError(t, err)
+	ricInd := e2apPdu.GetInitiatingMessage().GetProcedureCode().GetRicIndication().GetInitiatingMessage()
+	assert.Assert(t, ricInd != nil)
+	assert.Equal(t, int32(0), ricInd.GetProtocolIes().GetE2ApProtocolIes29().GetValue().GetRicRequestorId())
+	assert.Equal(t, int32(0), ricInd.GetProtocolIes().GetE2ApProtocolIes29().GetValue().GetRicInstanceId())
+	t.Log(e2apPdu)
+
+	ranFunctionID, ricActionID, ricCallProcessID, ricIndicationHeader, ricIndicationMessage, ricIndicationSn,
+		ricIndicationType, ricRequest, err := DecodeRicIndicationPdu(e2apPdu)
+	assert.NilError(t, err)
+	assert.Equal(t, 1, int(ranFunctionID), "unexpected ranFunctionID")
+	assert.Equal(t, 0, int(ricActionID), "unexpected ricActionID")
+	assert.DeepEqual(t, []byte{0x3F, 0x08, 0x37, 0x34, 0x37, 0x38, 0xB5, 0xC6, 0x77,
+		0x88, 0x02, 0x37, 0x34, 0x37, 0x22, 0x5B, 0xD6, 0x00, 0x70, 0x37, 0x34, 0x37,
+		0x98, 0x80, 0x31, 0x30, 0x30, 0x09, 0x09}, []byte(*ricIndicationHeader))
+	assert.DeepEqual(t, []byte{0x40, 0x00, 0x00, 0x4C, 0x0C, 0x66, 0x6F, 0x6F, 0x2D, 0x67, 0x4E, 0x42, 0x80, 0x00, 0x00},
+		[]byte(*ricIndicationMessage))
+	assert.Assert(t, is.Nil(ricCallProcessID))
+	assert.Equal(t, 0, int(ricIndicationSn), "unexpected ricIndicationSn")
+	assert.Equal(t, e2apies.RicindicationType_RICINDICATION_TYPE_REPORT, ricIndicationType, "unexpected ricIndicationType")
 	assert.Assert(t, ricRequest != nil)
 
 }

--- a/pkg/southbound/e2ap/test/RicIndication2.xml
+++ b/pkg/southbound/e2ap/test/RicIndication2.xml
@@ -1,0 +1,67 @@
+<E2AP-PDU>
+    <initiatingMessage>
+        <procedureCode>5</procedureCode>
+        <criticality><ignore/></criticality>
+        <value>
+            <RICindication>
+                <protocolIEs>
+                    <RICindication-IEs>
+                        <id>29</id>
+                        <criticality><reject/></criticality>
+                        <value>
+                            <RICrequestID>
+                                <ricRequestorID>0</ricRequestorID>
+                                <ricInstanceID>0</ricInstanceID>
+                            </RICrequestID>
+                        </value>
+                    </RICindication-IEs>
+                    <RICindication-IEs>
+                        <id>5</id>
+                        <criticality><reject/></criticality>
+                        <value>
+                            <RANfunctionID>1</RANfunctionID>
+                        </value>
+                    </RICindication-IEs>
+                    <RICindication-IEs>
+                        <id>15</id>
+                        <criticality><reject/></criticality>
+                        <value>
+                            <RICactionID>0</RICactionID>
+                        </value>
+                    </RICindication-IEs>
+                    <RICindication-IEs>
+                        <id>27</id>
+                        <criticality><reject/></criticality>
+                        <value>
+                            <RICindicationSN>0</RICindicationSN>
+                        </value>
+                    </RICindication-IEs>
+                    <RICindication-IEs>
+                        <id>28</id>
+                        <criticality><reject/></criticality>
+                        <value>
+                            <RICindicationType><report/></RICindicationType>
+                        </value>
+                    </RICindication-IEs>
+                    <RICindication-IEs>
+                        <id>25</id>
+                        <criticality><reject/></criticality>
+                        <value>
+                            <RICindicationHeader>
+                                3F 08 37 34 37 38 B5 C6 77 88 02 37 34 37 22 5B
+                                D6 00 70 37 34 37 98 80 31 30 30 09 09
+                            </RICindicationHeader>
+                        </value>
+                    </RICindication-IEs>
+                    <RICindication-IEs>
+                        <id>26</id>
+                        <criticality><reject/></criticality>
+                        <value>
+                            <RICindicationMessage>40 00 00 4C 0C 66 6F 6F 2D 67 4E 42 80 00 00</RICindicationMessage>
+                        </value>
+                    </RICindication-IEs>
+                </protocolIEs>
+            </RICindication>
+        </value>
+    </initiatingMessage>
+</E2AP-PDU>


### PR DESCRIPTION
Taking RicIndication XER fro @woojoong88 and decoding to prove that when values are 0 ProtoBuf output optimizes it