### PR TITLE
Addressing error which linters v1.34.1 raises on unit test

### DIFF
--- a/pkg/southbound/e2ap/asn1cgo/BIT_STRING_test.go
+++ b/pkg/southbound/e2ap/asn1cgo/BIT_STRING_test.go
@@ -53,7 +53,7 @@ func Test_decodeBitString(t *testing.T) {
 
 	protoBitString, err := decodeBitString(bsC)
 	assert.NilError(t, err)
-	//assert.Assert(t, protoBitString != nil)
+	//assert.Assert(t, protoBitString != nil) // Commented due to the Linters (v1.34.1) error - possible nil pointer dereference (https://staticcheck.io/docs/checks#SA5011) on lines 57 & 58
 	assert.Equal(t, int(protoBitString.Len), 28, "unexpected bit string length")
 	assert.Equal(t, protoBitString.Value, uint64(0xf0debc9a), "unexpected bit string value")
 
@@ -72,7 +72,7 @@ func Test_decodeBitString2(t *testing.T) {
 
 	protoBitString, err := decodeBitString(bsC)
 	assert.NilError(t, err)
-	//assert.Assert(t, protoBitString != nil)
+	//assert.Assert(t, protoBitString != nil) // Commented due to the Linters (v1.34.1) error - possible nil pointer dereference (https://staticcheck.io/docs/checks#SA5011) on lines 76 & 77
 	assert.Equal(t, int(protoBitString.Len), 22, "unexpected bit string length")
 	assert.Equal(t, protoBitString.Value, uint64(0xd4bc9a), "unexpected bit string value")
 

--- a/pkg/southbound/e2ap/asn1cgo/E2setupRequest_test.go
+++ b/pkg/southbound/e2ap/asn1cgo/E2setupRequest_test.go
@@ -50,7 +50,7 @@ func Test_E2setupRequest(t *testing.T) {
 	// Now reverse it and decode the other way round to a Go struct
 	e2srFedback, err := decodeE2setupRequest(e2srC)
 	assert.NilError(t, err)
-	//assert.Assert(t, e2srFedback != nil)
+	//assert.Assert(t, e2srFedback != nil) //Commented due to the Linters (v1.34.1) error - possible nil pointer dereference (https://staticcheck.io/docs/checks#SA5011) on line 54
 	ge2nID := e2srFedback.ProtocolIes.E2ApProtocolIes3.Value.GlobalE2NodeId.(*e2apies.GlobalE2NodeId_GNb)
 	assert.Equal(t, "ONF", string(ge2nID.GNb.GlobalGNbId.PlmnId.Value))
 	gnbID := ge2nID.GNb.GlobalGNbId.GnbId.GnbIdChoice.(*e2apies.GnbIdChoice_GnbId)

--- a/pkg/southbound/e2ap/asn1cgo/GlobalENB-ID_test.go
+++ b/pkg/southbound/e2ap/asn1cgo/GlobalENB-ID_test.go
@@ -29,14 +29,14 @@ func TestNewGlobaleNBID(t *testing.T) {
 
 	cobject, err := newGlobaleNBID(&g)
 	assert.NilError(t, err, "error converting to c struct")
-	//assert.Assert(t, cobject != nil)
+	//assert.Assert(t, cobject != nil) //Commented due to the Linters (v1.34.1) error - possible nil pointer dereference (https://staticcheck.io/docs/checks#SA5011) on lines 33 & 34
 	assert.Equal(t, int(cobject.pLMN_Identity.size), 3, "expected plmn id to be 3 bytes")
 	assert.Equal(t, int(cobject.eNB_ID.present), 2, "expected choice to be 1 (home_eNB_ID)")
 
 	// Now do the reverse - C object back to struct
 	g1, err := decodeGlobalEnbID(cobject)
 	assert.NilError(t, err, "error converting back from c struct")
-	//assert.Assert(t, g1 != nil)
+	//assert.Assert(t, g1 != nil) //Commented due to the Linters (v1.34.1) error - possible nil pointer dereference (https://staticcheck.io/docs/checks#SA5011) on line 40
 	assert.Equal(t, string(g1.PLmnIdentity.Value), "ONF", "unexpected value for Plmn ID")
 	switch choice := g1.ENbId.EnbId.(type) {
 	case *e2apies.EnbId_HomeENbId:

--- a/pkg/southbound/e2ap/asn1cgo/GlobalgNB-ID_test.go
+++ b/pkg/southbound/e2ap/asn1cgo/GlobalgNB-ID_test.go
@@ -29,14 +29,14 @@ func TestNewGlobalgNBID(t *testing.T) {
 
 	cobject, err := newGlobalgNBID(&g)
 	assert.NilError(t, err, "error converting to c struct")
-	//assert.Assert(t, cobject != nil)
+	//assert.Assert(t, cobject != nil) //Commented due to the Linters (v1.34.1) error - possible nil pointer dereference (https://staticcheck.io/docs/checks#SA5011) on lines 33 & 34
 	assert.Equal(t, int(cobject.plmn_id.size), 3, "expected plmn id to be 3 bytes")
 	assert.Equal(t, int(cobject.gnb_id.present), 1, "expected choice to be 1 (gnb_id)")
 
 	// Now do the reverse - C object back to struct
 	g1, err := decodeGlobalGnbID(cobject)
 	assert.NilError(t, err, "error converting back from c struct")
-	//assert.Assert(t, g1 != nil)
+	//assert.Assert(t, g1 != nil) //Commented due to the Linters (v1.34.1) error - possible nil pointer dereference (https://staticcheck.io/docs/checks#SA5011) on line 40
 	assert.Equal(t, string(g1.PlmnId.Value), "ONF", "unexpected value for Plmn ID")
 	switch choice := g1.GnbId.GnbIdChoice.(type) {
 	case *e2apies.GnbIdChoice_GnbId:

--- a/pkg/southbound/e2ap/pdudecoder/e2SetupResponseDecoder_test.go
+++ b/pkg/southbound/e2ap/pdudecoder/e2SetupResponseDecoder_test.go
@@ -19,7 +19,7 @@ func Test_DecodeE2SetupResponsePdu(t *testing.T) {
 
 	ricIdentity, ranFunctionsAccepted, ranFunctionsRejected, err := DecodeE2SetupResponsePdu(e2apPdu)
 	assert.NilError(t, err)
-	//assert.Assert(t, ricIdentity != nil)
+	//assert.Assert(t, ricIdentity != nil) //Commented due to the Linters (v1.34.1) error - possible nil pointer dereference (https://staticcheck.io/docs/checks#SA5011) on lines 23, 24 & 25
 	assert.Equal(t, "ONF", string([]byte{ricIdentity.PlmnID[0], ricIdentity.PlmnID[1], ricIdentity.PlmnID[2]}))
 	assert.Equal(t, 20, int(ricIdentity.RicIdentifier.RicIdentifierLen))
 	assert.Equal(t, 0xBCDE, int(ricIdentity.RicIdentifier.RicIdentifierValue))
@@ -50,7 +50,7 @@ func Test_DecodeE2SetupResponsePduCuCp(t *testing.T) {
 
 	ricIdentity, ranFunctionsAccepted, ranFunctionsRejected, err := DecodeE2SetupResponsePdu(e2apPdu)
 	assert.NilError(t, err)
-	//assert.Assert(t, ricIdentity != nil)
+	//assert.Assert(t, ricIdentity != nil) //Commented due to the Linters (v1.34.1) error - possible nil pointer dereference (https://staticcheck.io/docs/checks#SA5011) on lines 54, 55 & 56
 	assert.DeepEqual(t, []byte{0x00, 0x02, 0x10}, []byte{ricIdentity.PlmnID[0], ricIdentity.PlmnID[1], ricIdentity.PlmnID[2]})
 	assert.Equal(t, 20, int(ricIdentity.RicIdentifier.RicIdentifierLen))
 	assert.Equal(t, 0x1, int(ricIdentity.RicIdentifier.RicIdentifierValue))

--- a/pkg/southbound/e2ap/pdudecoder/e2setupRequestDecoder_test.go
+++ b/pkg/southbound/e2ap/pdudecoder/e2setupRequestDecoder_test.go
@@ -20,11 +20,11 @@ func Test_DecodeE2SetupRequestPdu(t *testing.T) {
 
 	identifier, ranFunctions, err := DecodeE2SetupRequestPdu(e2apPdu)
 	assert.NilError(t, err)
-	//assert.Assert(t, identifier != nil)
+	//assert.Assert(t, identifier != nil) //Commented due to the Linters (v1.34.1) error - possible nil pointer dereference (https://staticcheck.io/docs/checks#SA5011) on lines 24, 25 & 26
 	assert.DeepEqual(t, []byte{0x00, 0x02, 0x10}, []byte{identifier.Plmn[0], identifier.Plmn[1], identifier.Plmn[2]})
 	assert.Equal(t, types.E2NodeTypeENB, identifier.NodeType)
 	assert.DeepEqual(t, []byte{0x00, 0xE0, 0x00}, identifier.NodeIdentifier)
 
-	//assert.Assert(t, ranFunctions != nil)
+	//assert.Assert(t, ranFunctions != nil) //Commented due to the Linters (v1.34.1) error - possible nil pointer dereference (https://staticcheck.io/docs/checks#SA5011) on line 29
 	assert.Equal(t, 1, len(*ranFunctions))
 }

--- a/pkg/southbound/e2ap/pdudecoder/ricSubscriptionDeleteFailureDecoder_test.go
+++ b/pkg/southbound/e2ap/pdudecoder/ricSubscriptionDeleteFailureDecoder_test.go
@@ -19,10 +19,10 @@ func Test_DecodeRicSubscriptionDeleteFailurePdu(t *testing.T) {
 
 	rfID, rrID, err := DecodeRicSubscriptionDeleteFailurePdu(e2apPdu)
 	assert.NilError(t, err)
-	//assert.Assert(t, rfID != nil)
+	//assert.Assert(t, rfID != nil) //Commented due to the Linters (v1.34.1) error - possible nil pointer dereference (https://staticcheck.io/docs/checks#SA5011) on line 23
 	assert.Equal(t, 9, int(*rfID))
 
-	//assert.Assert(t, rrID != nil)
+	//assert.Assert(t, rrID != nil) //Commented due to the Linters (v1.34.1) error - possible nil pointer dereference (https://staticcheck.io/docs/checks#SA5011) on lines 26 & 27
 	assert.Equal(t, 22, int(rrID.RequestorID))
 	assert.Equal(t, 6, int(rrID.InstanceID))
 

--- a/pkg/southbound/e2ap/pdudecoder/ricSubscriptionDeleteResponseDecoder_test.go
+++ b/pkg/southbound/e2ap/pdudecoder/ricSubscriptionDeleteResponseDecoder_test.go
@@ -19,10 +19,10 @@ func Test_DecodeRicSubscriptionDeleteResponsePdu(t *testing.T) {
 
 	rfID, rrID, err := DecodeRicSubscriptionDeleteResponsePdu(e2apPdu)
 	assert.NilError(t, err)
-	//assert.Assert(t, rfID != nil)
+	//assert.Assert(t, rfID != nil) //Commented due to the Linters (v1.34.1) error - possible nil pointer dereference (https://staticcheck.io/docs/checks#SA5011) on line 23
 	assert.Equal(t, 9, int(*rfID))
 
-	//assert.Assert(t, rrID != nil)
+	//assert.Assert(t, rrID != nil) //Commented due to the Linters (v1.34.1) error - possible nil pointer dereference (https://staticcheck.io/docs/checks#SA5011) on lines 26 & 27
 	assert.Equal(t, 22, int(rrID.RequestorID))
 	assert.Equal(t, 6, int(rrID.InstanceID))
 

--- a/pkg/southbound/e2ap/pdudecoder/ricSubscriptionFailureDecoder_test.go
+++ b/pkg/southbound/e2ap/pdudecoder/ricSubscriptionFailureDecoder_test.go
@@ -22,10 +22,10 @@ func Test_DecodeRicSubscriptionFailurePdu(t *testing.T) {
 
 	rrID, rfID, pc, crit, tm, critReq, causes, diags, err := DecodeRicSubscriptionFailurePdu(e2apPdu)
 	assert.NilError(t, err)
-	//assert.Assert(t, rfID != nil)
+	//assert.Assert(t, rfID != nil) //Commented due to the Linters (v1.34.1) error - possible nil pointer dereference (https://staticcheck.io/docs/checks#SA5011) on line 26
 	assert.Equal(t, 9, int(*rfID))
 
-	//assert.Assert(t, rrID != nil)
+	//assert.Assert(t, rrID != nil) //Commented due to the Linters (v1.34.1) error - possible nil pointer dereference (https://staticcheck.io/docs/checks#SA5011) on lines 29 & 30
 	assert.Equal(t, 22, int(rrID.RequestorID))
 	assert.Equal(t, 6, int(rrID.InstanceID))
 
@@ -38,7 +38,7 @@ func Test_DecodeRicSubscriptionFailurePdu(t *testing.T) {
 	// TODO: Should be 20
 	assert.Equal(t, 0, int(critReq.InstanceID))
 
-	//assert.Assert(t, causes != nil)
+	assert.Assert(t, causes != nil)
 	for id, cause := range causes {
 		switch id {
 		case 100:

--- a/pkg/southbound/e2ap/pdudecoder/ricSubscriptionResponseDecoder_test.go
+++ b/pkg/southbound/e2ap/pdudecoder/ricSubscriptionResponseDecoder_test.go
@@ -19,10 +19,10 @@ func Test_DecodeRicSubscriptionResponsePdu(t *testing.T) {
 
 	rfID, rrID, ricActionIDs, _, err := DecodeRicSubscriptionResponsePdu(e2apPdu)
 	assert.NilError(t, err)
-	//assert.Assert(t, rfID != nil)
+	//assert.Assert(t, rfID != nil) //Commented due to the Linters (v1.34.1) error - possible nil pointer dereference (https://staticcheck.io/docs/checks#SA5011) on lines 23
 	assert.Equal(t, 20, int(*rfID))
 
-	//assert.Assert(t, rrID != nil)
+	//assert.Assert(t, rrID != nil) //Commented due to the Linters (v1.34.1) error - possible nil pointer dereference (https://staticcheck.io/docs/checks#SA5011) on lines 26 & 27
 	assert.Equal(t, 22, int(rrID.RequestorID))
 	assert.Equal(t, 6, int(rrID.InstanceID))
 


### PR DESCRIPTION
Could be either merged or abandoned - it's up to you. Somehow, in the future, if testing suit would be upgraded to the latest version, in particular `linters`, this patch could save some time