### PR TITLE
[TO BE CONSIDERED] Small change in proto constant

### DIFF
--- a/api/e2ap/v1beta1/e2ap-commondatatypes/e2ap_commondatatypes.pb.go
+++ b/api/e2ap/v1beta1/e2ap-commondatatypes/e2ap_commondatatypes.pb.go
@@ -83,9 +83,9 @@ func (Presence) EnumDescriptor() ([]byte, []int) {
 type TriggeringMessage int32
 
 const (
-	TriggeringMessage_TRIGGERING_MESSAGE_INITIATING_MESSAGE    TriggeringMessage = 0
-	TriggeringMessage_TRIGGERING_MESSAGE_SUCCESSFUL_OUTCOME    TriggeringMessage = 1
-	TriggeringMessage_TRIGGERING_MESSAGE_UNSUCCESSFULL_OUTCOME TriggeringMessage = 2
+	TriggeringMessage_TRIGGERING_MESSAGE_INITIATING_MESSAGE   TriggeringMessage = 0
+	TriggeringMessage_TRIGGERING_MESSAGE_SUCCESSFUL_OUTCOME   TriggeringMessage = 1
+	TriggeringMessage_TRIGGERING_MESSAGE_UNSUCCESSFUL_OUTCOME TriggeringMessage = 2
 )
 
 var TriggeringMessage_name = map[int32]string{

--- a/pkg/southbound/e2ap/asn1cgo/CriticalityDiagnostics_test.go
+++ b/pkg/southbound/e2ap/asn1cgo/CriticalityDiagnostics_test.go
@@ -24,7 +24,7 @@ func Test_CriticalityDiagnostics(t *testing.T) {
 				Transport: e2apies.CauseTransport_CAUSE_TRANSPORT_TRANSPORT_RESOURCE_UNAVAILABLE,
 			},
 		}, v1beta1.ProcedureCodeIDRICsubscription, e2ap_commondatatypes.Criticality_CRITICALITY_IGNORE,
-		e2ap_commondatatypes.TriggeringMessage_TRIGGERING_MESSAGE_UNSUCCESSFULL_OUTCOME,
+		e2ap_commondatatypes.TriggeringMessage_TRIGGERING_MESSAGE_UNSUCCESSFUL_OUTCOME,
 		&types.RicRequest{
 			RequestorID: 10,
 			InstanceID:  20,

--- a/pkg/southbound/e2ap/asn1cgo/TriggeringMessage.go
+++ b/pkg/southbound/e2ap/asn1cgo/TriggeringMessage.go
@@ -23,7 +23,7 @@ func newTriggeringMessage(tm e2ap_commondatatypes.TriggeringMessage) (C.Triggeri
 		ret = C.TriggeringMessage_initiating_message
 	case e2ap_commondatatypes.TriggeringMessage_TRIGGERING_MESSAGE_SUCCESSFUL_OUTCOME:
 		ret = C.TriggeringMessage_successful_outcome
-	case e2ap_commondatatypes.TriggeringMessage_TRIGGERING_MESSAGE_UNSUCCESSFULL_OUTCOME:
+	case e2ap_commondatatypes.TriggeringMessage_TRIGGERING_MESSAGE_UNSUCCESSFUL_OUTCOME:
 		ret = C.TriggeringMessage_unsuccessfull_outcome
 	default:
 		return 0, fmt.Errorf("unexpected TriggeringMessage %v", tm)

--- a/pkg/southbound/e2ap/pdubuilder/ric-subscription-delete-failure_test.go
+++ b/pkg/southbound/e2ap/pdubuilder/ric-subscription-delete-failure_test.go
@@ -23,7 +23,7 @@ func TestRicSubscriptionDeleteFailure(t *testing.T) {
 				Transport: e2apies.CauseTransport_CAUSE_TRANSPORT_TRANSPORT_RESOURCE_UNAVAILABLE,
 			},
 		}, v1beta1.ProcedureCodeIDRICsubscription, e2ap_commondatatypes.Criticality_CRITICALITY_IGNORE,
-		e2ap_commondatatypes.TriggeringMessage_TRIGGERING_MESSAGE_UNSUCCESSFULL_OUTCOME,
+		e2ap_commondatatypes.TriggeringMessage_TRIGGERING_MESSAGE_UNSUCCESSFUL_OUTCOME,
 		&types.RicRequest{
 			RequestorID: 10,
 			InstanceID:  20,

--- a/pkg/southbound/e2ap/pdubuilder/ric-subscription-failure_test.go
+++ b/pkg/southbound/e2ap/pdubuilder/ric-subscription-failure_test.go
@@ -31,7 +31,7 @@ func TestRicSubscriptionFailure(t *testing.T) {
 		InstanceID:  6,
 	}, 9,
 		v1beta1.ProcedureCodeIDRICsubscription, e2ap_commondatatypes.Criticality_CRITICALITY_IGNORE,
-		e2ap_commondatatypes.TriggeringMessage_TRIGGERING_MESSAGE_UNSUCCESSFULL_OUTCOME,
+		e2ap_commondatatypes.TriggeringMessage_TRIGGERING_MESSAGE_UNSUCCESSFUL_OUTCOME,
 		&types.RicRequest{
 			RequestorID: 10,
 			InstanceID:  20,

--- a/pkg/southbound/e2ap/pdudecoder/ricSubscriptionFailureDecoder_test.go
+++ b/pkg/southbound/e2ap/pdudecoder/ricSubscriptionFailureDecoder_test.go
@@ -31,7 +31,7 @@ func Test_DecodeRicSubscriptionFailurePdu(t *testing.T) {
 
 	assert.Equal(t, v1beta1.ProcedureCodeIDRICsubscription, pc)
 	assert.Equal(t, e2ap_commondatatypes.Criticality_CRITICALITY_IGNORE, crit)
-	assert.Equal(t, e2ap_commondatatypes.TriggeringMessage_TRIGGERING_MESSAGE_UNSUCCESSFULL_OUTCOME, tm)
+	assert.Equal(t, e2ap_commondatatypes.TriggeringMessage_TRIGGERING_MESSAGE_UNSUCCESSFUL_OUTCOME, tm)
 
 	// TODO: Should be 10
 	assert.Equal(t, 10, int(critReq.RequestorID))


### PR DESCRIPTION
This PR targets to fix issue with `make linters`. This is the reason why PR#155 crashes with Travis build.
Since this change touches `Generated` Protobuf - merge should be carefully considered.