### PR TITLE
Allow integration tests to use the chart repo rather than local charts

### DIFF
--- a/test/e2/subscription.go
+++ b/test/e2/subscription.go
@@ -79,7 +79,8 @@ func createSubscriptionRequest(nodeID string) (subscription.SubscriptionDetails,
 
 // TestSubscription
 func (s *TestSuite) TestSubscription(t *testing.T) {
-	utils.CreateRanSimulatorWithName(t, "ran-simulator")
+	sim := utils.CreateRanSimulatorWithName(t, "ran-simulator")
+	assert.Assert(t, sim != nil)
 
 	clientConfig := e2client.Config{
 		AppID: "subscription-test",

--- a/test/utils/sdran.go
+++ b/test/utils/sdran.go
@@ -8,15 +8,38 @@ import (
 	"testing"
 
 	"github.com/onosproject/helmit/pkg/helm"
+	"github.com/onosproject/helmit/pkg/kubernetes"
 	"github.com/onosproject/helmit/pkg/util/random"
 	"github.com/onosproject/onos-test/pkg/onostest"
 	"github.com/stretchr/testify/assert"
 )
 
+func getCredentials() (string, string, error) {
+	kubClient, err := kubernetes.New()
+	if err != nil {
+		return "", "", err
+	}
+	secrets, err := kubClient.CoreV1().Secrets().Get(onostest.SecretsName)
+	if err != nil {
+		return "", "", err
+	}
+	username := string(secrets.Object.Data["sd-ran-username"])
+	password := string(secrets.Object.Data["sd-ran-password"])
+
+	return username, password, nil
+}
+
 // CreateSdranRelease creates a helm release for an sd-ran instance
 func CreateSdranRelease() (*helm.HelmRelease, error) {
+	username, password, err := getCredentials()
+	if err != nil {
+		return nil, err
+	}
+
 	sdran := helm.Chart("sd-ran", onostest.SdranChartRepo).
 		Release("sd-ran").
+		SetUsername(username).
+		SetPassword(password).
 		Set("import.onos-config.enabled", false).
 		Set("import.onos-topo.enabled", false).
 		Set("onos-e2t.image.tag", "latest").
@@ -32,11 +55,16 @@ func CreateRanSimulator(t *testing.T) *helm.HelmRelease {
 
 // CreateRanSimulatorWithName creates a ran simulator
 func CreateRanSimulatorWithName(t *testing.T, name string) *helm.HelmRelease {
+	username, password, err := getCredentials()
+	assert.NoError(t, err)
+
 	simulator := helm.
 		Chart(name, onostest.SdranChartRepo).
 		Release(name).
+		SetUsername(username).
+		SetPassword(password).
 		Set("image.tag", "latest")
-	err := simulator.Install(true)
+	err = simulator.Install(true)
 	assert.NoError(t, err, "could not install device simulator %v", err)
 
 	return simulator


### PR DESCRIPTION
This PR adds the ability to specify a username/password to helmit and download charts from the sdran chart repo.

helmit test -n test --secret "sd-ran-username=XXX" --secret "sd-ran-password=XXX" ./cmd/onos-e2t-tests