### PR TITLE
Close E2AP channel on error

### DIFF
--- a/pkg/protocols/e2/channels/channel.go
+++ b/pkg/protocols/e2/channels/channel.go
@@ -137,17 +137,14 @@ func (c *threadSafeChannel) processRecvs() {
 	buf := make([]byte, c.options.RecvBufferSize)
 	for {
 		n, err := c.conn.Read(buf)
-		if err == io.EOF {
+		if err != nil {
 			c.Close()
 			return
 		}
+
+		err = c.processRecv(buf[:n])
 		if err != nil {
 			log.Error(err)
-		} else {
-			err := c.processRecv(buf[:n])
-			if err != nil {
-				log.Error(err)
-			}
 		}
 	}
 }

--- a/pkg/protocols/e2ap101/channels/channel.go
+++ b/pkg/protocols/e2ap101/channels/channel.go
@@ -137,17 +137,14 @@ func (c *threadSafeChannel) processRecvs() {
 	buf := make([]byte, c.options.RecvBufferSize)
 	for {
 		n, err := c.conn.Read(buf)
-		if err == io.EOF {
+		if err != nil {
 			c.Close()
 			return
 		}
+
+		err = c.processRecv(buf[:n])
 		if err != nil {
 			log.Error(err)
-		} else {
-			err := c.processRecv(buf[:n])
-			if err != nil {
-				log.Error(err)
-			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes a bug in E2AP channels allowing the channels to enter an infinite loop when the other side of the connection is down.