### PR TITLE
Complete subscription delete when failure cause is request type

### DIFF
--- a/pkg/controller/subscription/controller.go
+++ b/pkg/controller/subscription/controller.go
@@ -388,7 +388,11 @@ func (r *Reconciler) reconcileCloseSubscriptionTask(task *subtaskapi.Subscriptio
 			return controller.Result{}, err
 		}
 	} else if failure != nil {
-		log.Warnf("Failed to initialize SubscriptionTask %+v: %s", task, err)
+		switch failure.ProtocolIes.E2ApProtocolIes1.Value.Cause.(type) {
+		case *e2apies.Cause_RicRequest:
+			return controller.Result{}, nil
+		}
+		log.Warnf("SubscriptionDeleteRequest %+v failed: %+v", request, failure)
 		return controller.Result{}, fmt.Errorf("failed to delete subscription %+v", sub)
 	}
 	return controller.Result{}, nil


### PR DESCRIPTION
This PR treats request failures as successes when returned by the E2 node in response to subscription delete requests. This ensures the controller can delete subscriptions that don't exist without failure.