### PR TITLE
check if the action definition pyalod is not nil

### DIFF
--- a/pkg/northbound/e2/v1beta1/subscription.go
+++ b/pkg/northbound/e2/v1beta1/subscription.go
@@ -7,8 +7,9 @@ package v1beta1
 import (
 	"crypto/md5"
 	"fmt"
-	"github.com/gogo/protobuf/proto"
 	"io"
+
+	"github.com/gogo/protobuf/proto"
 
 	substoreapi "github.com/onosproject/onos-e2t/api/onos/e2t/store/subscription"
 	subbroker "github.com/onosproject/onos-e2t/pkg/broker/subscription/v1beta1"
@@ -98,7 +99,7 @@ func (s *SubscriptionServer) Subscribe(request *e2api.SubscribeRequest, server e
 	actions := make([]substoreapi.SubscriptionAction, len(request.Subscription.Actions))
 	for i, action := range request.Subscription.Actions {
 		actionBytes := action.Payload
-		if encoding == e2api.Encoding_PROTO {
+		if encoding == e2api.Encoding_PROTO && action.Payload != nil {
 			actionBytes, err = serviceModelPlugin.ActionDefinitionProtoToASN1(actionBytes)
 			if err != nil {
 				log.Error(err)


### PR DESCRIPTION
If a service model doesn't support action definition then it can be null. To make sure we don't call ActionDefintionProtoToAsn1 function for  a SM that doesn't support it, we need to check the value is not nil 