### PR TITLE
FB kpimon issue

### DIFF
--- a/pkg/southbound/e2ap101/pdubuilder/ric-subscription-request_test.go
+++ b/pkg/southbound/e2ap101/pdubuilder/ric-subscription-request_test.go
@@ -4,6 +4,7 @@
 package pdubuilder
 
 import (
+	"encoding/hex"
 	e2apies "github.com/onosproject/onos-e2t/api/e2ap/v1beta2/e2ap-ies"
 	"github.com/onosproject/onos-e2t/pkg/southbound/e2ap101/asn1cgo"
 	"github.com/onosproject/onos-e2t/pkg/southbound/e2ap101/types"
@@ -30,14 +31,22 @@ func TestRicSubscriptionRequest(t *testing.T) {
 	}
 
 	newE2apPdu, err := CreateRicSubscriptionRequestE2apPdu(
-		types.RicRequest{RequestorID: 1, InstanceID: 2},
-		3, []byte{0x55, 0x66}, ricActionsToBeSetup)
+		types.RicRequest{RequestorID: 2, InstanceID: 1},
+		3, []byte{0x08, 0x03, 0xe7},
+		//ToDo - absence of RICactionsToBeSetup list is the reason why PER encoding is crushing
+		nil) //ricActionsToBeSetup)
+	//[]byte{0x5c, 0x30, 0x31, 0x30, 0x5c, 0x30, 0x30, 0x33, 0x5c, 0x33, 0x34, 0x37}
 
 	assert.NilError(t, err)
 	assert.Assert(t, newE2apPdu != nil)
+	t.Logf("Hexdump of bytes is \n%v", hex.Dump([]byte("\010\003\347")))
+	t.Logf("Message is \n%v", newE2apPdu.GetInitiatingMessage().GetProcedureCode().GetRicSubscription().GetInitiatingMessage())
 
 	xer, err := asn1cgo.XerEncodeE2apPdu(newE2apPdu)
 	assert.NilError(t, err)
 	t.Logf("RicSubscriptionRequest E2AP PDU\n%s", xer)
 
+	per, err := asn1cgo.PerEncodeE2apPdu(newE2apPdu)
+	assert.NilError(t, err)
+	t.Logf("RicSubscriptionRequest E2AP PDU\n%v", hex.Dump(per))
 }


### PR DESCRIPTION
Absence of RICactionsToBeSetup list, which is mandatory, leads PER encoding to crush.
This unit test reproduces this issue