### PR TITLE
Set channel disconnect timestamp when updating term/master

### DIFF
--- a/pkg/controller/v1beta1/channel/controller.go
+++ b/pkg/controller/v1beta1/channel/controller.go
@@ -301,6 +301,8 @@ func (r *Reconciler) reconcileMastership(ctx context.Context, channel *e2api.Cha
 	}
 
 	// Update the channel status with the new term/master
+	currentTime := time.Now()
+	channel.Status.Timestamp = &currentTime
 	channel.Status.Term = mastership.Term
 	channel.Status.Master = string(e2NodeRelation.GetRelation().SrcEntityID)
 	if err := r.chans.Update(ctx, channel); err != nil && !errors.IsNotFound(err) && !errors.IsConflict(err) {


### PR DESCRIPTION
This PR sets the failure timestamp on a `Channel` when the channel reconciler updates the mastership term. This ensures failure detection will work when mastership changes and the client disconnects at the same time.